### PR TITLE
Avax frendLend and bullaFinance subgraph deploy

### DIFF
--- a/bulla-contracts/config/avalanche.json
+++ b/bulla-contracts/config/avalanche.json
@@ -5,5 +5,7 @@
   "bullaManager": { "address": "0xAA6E5B4E34f3C3BA4D90694909dca7DDdf058079", "startBlock": 5968486 },
   "bullaClaim": { "address": "0x68da2c92b60337aA55BAcF0d7e61126eDb535752", "startBlock": 5968486 },
   "bullaBanker": { "address": "0x4Ba1453df995F4AAe2ef610A9c06fEecF0Fe2581", "startBlock": 5968486 },
+  "bullaFinance": { "address": "0x15250D092a789e2304472eD581D587B714615d24", "startBlock": 30723370 },
+  "frendLend": { "address": "0xBAD5c53cC6b37d706E6153d397864E5fdbD38170", "startBlock": 30723390 },
   "instantPayment": { "address": "0xFcA0E74af938919E43541D40330212324C8aF27F", "startBlock": 12787205 }
 }


### PR DESCRIPTION

Build completed: QmdUtUu8Xj6qhu5mKucdAya3udnvPmUwuZoXRGXqpZSXXv

Deployed to https://thegraph.com/explorer/subgraph/bulla-network/bulla-contracts-avalanche

Subgraph endpoints:
Queries (HTTP):     https://api.thegraph.com/subgraphs/name/bulla-network/bulla-contracts-avalanche