### PR TITLE
feat: add TARAM factoring V2.1 pool for XDC Network

### DIFF
--- a/bulla-contracts/config/xdc.json
+++ b/bulla-contracts/config/xdc.json
@@ -15,5 +15,7 @@
   "bullaFactoringFactoryV2_1": { "address": "0x0000000000000000000000000000000000000000", "startBlock": 101437284 },
   "bullaFactoringV0Pools": [],
   "bullaFactoringV1Pools": [],
-  "bullaFactoringV2_1Pools": []
+  "bullaFactoringV2_1Pools": [
+    { "name": "TARAM", "address": "0xa259331Cd3daCC5D1229beA06BAc7d957614a64E", "startBlock": 101437284 }
+  ]
 }


### PR DESCRIPTION
## Summary

- Adds the TARAM factoring V2.1 pool to the XDC subgraph configuration
- Pool address: `0xa259331Cd3daCC5D1229beA06BAc7d957614a64E`
- Start block: `101437284`

## Changes

Updated `bulla-contracts/config/xdc.json` to populate the `bullaFactoringV2_1Pools` array with the TARAM pool entry.

Replaces the closed PR #118 which had stale commits from an older main branch.