### PR TITLE
denormalize Bulla state so clients stop replaying event logs

### DIFF
--- a/bulla-contracts/schema.graphql
+++ b/bulla-contracts/schema.graphql
@@ -940,6 +940,13 @@ type User @entity {
   invoiceEvents: [IEventLog!]!
 }
 
+type BullaTransaction @entity {
+  id: ID! # transactionHash (hex)
+  txHash: Bytes!
+  user: User!
+  timestamp: BigInt!
+}
+
 type UserClaimStats @entity {
   id: ID! # user address (hex, lowercased) — same as User.id
   user: User!

--- a/bulla-contracts/schema.graphql
+++ b/bulla-contracts/schema.graphql
@@ -673,12 +673,14 @@ type Claim @entity {
   creator: User! # address
   creditor: User! # address
   debtor: User! # address
+  originalCreditor: Bytes! #address
   amount: BigInt!
   paidAmount: BigInt!
   isTransferred: Boolean!
   description: String!
   created: BigInt!
   dueBy: BigInt!
+  lastPaymentDate: BigInt # Blocktime 
   claimType: ClaimType!
   token: Token!
   status: ClaimStatus!
@@ -690,6 +692,134 @@ type Claim @entity {
   lastUpdatedBlockNumber: BigInt!
   lastUpdatedTimestamp: BigInt!
   factoringStatus: ClaimFactoringStatus
+  # Invoice-specific details, present only when the claim was created via
+  # BullaInvoice. 1:1 sub-entity keyed by claim.id.
+  invoiceDetails: InvoiceDetails
+  # Financing (frendlend / vendor-financing) state, present only when the claim
+  # participates in a financing flow. 1:1 sub-entity keyed by claim.id.
+  financing: ClaimFinancing
+}
+
+# Invoice-specific details for claims created via BullaInvoice
+type InvoiceDetails @entity {
+  id: ID! # same as claim.id (TOKENID-VERSION)
+  claim: Claim!
+  deliveryDate: BigInt!
+  depositAmount: BigInt!
+  interestRateBps: Int!
+  numberOfPeriodsPerYear: Int!
+  # Flipped true on PurchaseOrderDelivered.
+  isDelivered: Boolean!
+  requestedByCreditor: Boolean!
+  isProtocolFeeExempt: Boolean!
+  # IPFS / attachment metadata captured at creation.
+  attachmentURI: String
+  tokenURI: String
+  lastUpdatedTimestamp: BigInt!
+  lastUpdatedBlock: BigInt!
+}
+
+enum ClaimFinancingKind {
+  Offered
+  Accepted
+}
+
+enum ClaimFinancingOrigination {
+  FrendLend
+  VendorFinancing
+}
+
+type ClaimFinancing @entity {
+  id: ID! # same as claim.id (TOKENID-VERSION)
+  claim: Claim!
+  kind: ClaimFinancingKind!
+  origination: ClaimFinancingOrigination!
+
+  # Terms (nullable; the populated subset depends on origination/version).
+  interestBps: Int
+  termLength: BigInt
+  minDownPaymentBps: Int # vendor-financing only
+  numberOfPeriodsPerYear: Int # frendlend v2 only
+  loanAmount: BigInt
+  impairmentGracePeriod: BigInt # frendlend v2 only
+
+  # For accepted vendor-financing: the tokenId of the originating claim the
+  # financed claim was spun out of.
+  originatingTokenId: String
+
+  # v2 frendlend payment aggregates (folded from LoanPayment events).
+  totalGrossInterestPaid: BigInt!
+  totalPrincipalPaid: BigInt!
+  totalProtocolFee: BigInt!
+  paymentCount: BigInt!
+  lastPaymentDate: BigInt
+
+  # v1 frendlend 1-wei acceptance sentinel: net values with the sentinel wei
+  # removed, so consumers don't re-walk logs to present the real amounts.
+  # Null for non-v1-frendlend financings.
+  netAmount: BigInt
+  netPaidAmount: BigInt
+
+  # For frendlend financings: the originating LoanOffer. Lets handleLoanPayment
+  # (which only carries claimId) fold payment aggregates back onto the offer.
+  loanOffer: LoanOffer
+
+  lastUpdatedTimestamp: BigInt!
+  lastUpdatedBlock: BigInt!
+}
+
+enum LoanOfferStatus {
+  Offered
+  Rejected
+  Accepted
+}
+
+type LoanOffer @entity {
+  id: ID! # loanId-version (e.g. "1-v1", "2-v2")
+  loanId: String!
+  version: BullaClaimVersion!
+  status: LoanOfferStatus!
+
+  # Offer terms (captured on LoanOffered).
+  offeredBy: Bytes! # address
+  creditor: Bytes! # address
+  debtor: Bytes! # address
+  loanAmount: BigInt!
+  token: Token! # address
+  interestBPS: Int!
+  numberOfPeriodsPerYear: Int # frendlend v2 only
+  termLength: BigInt!
+  expiresAt: BigInt # frendlend v2 only
+  description: String
+  ipfsHash: String # v1 attachment
+  attachmentURI: String # v2 metadata
+  tokenURI: String # v2 metadata
+  impairmentGracePeriod: BigInt # frendlend v2 only
+  offerDate: BigInt!
+  offerTxHash: Bytes!
+
+  # Acceptance (null until status == Accepted).
+  claim: Claim
+  claimId: String # TOKENID-VERSION
+  tokenId: String
+  receiver: Bytes # address
+  processingFee: BigInt
+  acceptedDate: BigInt
+  acceptedTxHash: Bytes
+
+  # Rejection (null until status == Rejected).
+  rejectedBy: Bytes # address
+  rejectedDate: BigInt
+  rejectedTxHash: Bytes
+
+  # Payment aggregates folded from LoanPayment (accepted frendlend v2 loans).
+  principalPaid: BigInt!
+  grossInterestPaid: BigInt!
+  protocolFee: BigInt!
+  lastPaymentDate: BigInt
+
+  lastUpdatedTimestamp: BigInt!
+  lastUpdatedBlock: BigInt!
 }
 
 # Factoring lifecycle state machine. Captures where a factored claim is in

--- a/bulla-contracts/schema.graphql
+++ b/bulla-contracts/schema.graphql
@@ -379,6 +379,12 @@ type InvoiceApprovedEvent implements IEventLog @entity {
   claim: Claim!
 }
 
+enum SwapOrderStatus {
+  Pending
+  Executed
+  Canceled
+}
+
 type OrderERC20 @entity {
   id: ID! # orderId
   orderId: BigInt!
@@ -389,6 +395,17 @@ type OrderERC20 @entity {
   senderWallet: Bytes! #address
   senderToken: Token! #address
   senderAmount: BigInt!
+  # Swap lifecycle: Pending on create, Executed on fill, Canceled on delete.
+  status: SwapOrderStatus!
+  createdAt: BigInt!
+  executedAt: BigInt # set on OrderExecuted
+  canceledAt: BigInt # set on OrderDeleted
+  # The address that received the signer's tokens (set on execution).
+  recipient: Bytes #address
+  # Hash of the most recent lifecycle transaction touching this order.
+  transactionHash: Bytes!
+  lastUpdatedBlock: BigInt!
+  lastUpdatedTimestamp: BigInt!
 }
 
 type OrderCreatedEvent implements IEventLog @entity {
@@ -645,6 +662,8 @@ type InstantPayment @entity {
   token: Token!
   ipfsHash: String
   description: String!
+  createdAt: BigInt!
+  transactionHash: Bytes!
   tag: [InstantPaymentTag!]! @derivedFrom(field: "instantPayment")
   logs: [IInstantPaymentEvent!]! @derivedFrom(field: "instantPayment")
 }

--- a/bulla-contracts/src/functions/BullaInvoice.ts
+++ b/bulla-contracts/src/functions/BullaInvoice.ts
@@ -1,6 +1,6 @@
 import { BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { FeeWithdrawn, InvoiceCreated, InvoicePaid, PurchaseOrderAccepted } from "../../generated/BullaInvoice/BullaInvoice";
-import { FeeWithdrawnEvent, InvoiceCreatedEvent, InvoicePaidEvent, PurchaseOrderAcceptedEvent, PurchaseOrderState } from "../../generated/schema";
+import { FeeWithdrawnEvent, InvoiceCreatedEvent, InvoiceDetails, InvoicePaidEvent, PurchaseOrderAcceptedEvent, PurchaseOrderState } from "../../generated/schema";
 
 export const getInvoiceCreatedEventId = (tokenId: BigInt, event: ethereum.Event): string =>
   "InvoiceCreated-" + tokenId.toString() + "-" + event.transaction.hash.toHexString() + "-" + event.logIndex.toString();
@@ -24,6 +24,24 @@ export const getPurchaseOrderDeliveredEventId = (tokenId: BigInt, event: ethereu
 export const getFeeWithdrawnEventId = (event: ethereum.Event): string => "FeeWithdrawn-" + event.transaction.hash.toHexString() + "-" + event.logIndex.toString();
 
 export const createFeeWithdrawnEvent = (event: FeeWithdrawn): FeeWithdrawnEvent => new FeeWithdrawnEvent(getFeeWithdrawnEventId(event));
+
+export const getOrCreateInvoiceDetails = (claimId: string, event: ethereum.Event): InvoiceDetails => {
+  let invoiceDetails = InvoiceDetails.load(claimId);
+  if (!invoiceDetails) {
+    invoiceDetails = new InvoiceDetails(claimId);
+    invoiceDetails.claim = claimId;
+    invoiceDetails.deliveryDate = BigInt.fromI32(0);
+    invoiceDetails.depositAmount = BigInt.fromI32(0);
+    invoiceDetails.interestRateBps = 0;
+    invoiceDetails.numberOfPeriodsPerYear = 0;
+    invoiceDetails.isDelivered = false;
+    invoiceDetails.requestedByCreditor = false;
+    invoiceDetails.isProtocolFeeExempt = false;
+  }
+  invoiceDetails.lastUpdatedTimestamp = event.block.timestamp;
+  invoiceDetails.lastUpdatedBlock = event.block.number;
+  return invoiceDetails;
+};
 
 export const getPurchaseOrderState = (claimId: string): PurchaseOrderState | null => {
   return PurchaseOrderState.load(claimId);

--- a/bulla-contracts/src/functions/BullaSwap.ts
+++ b/bulla-contracts/src/functions/BullaSwap.ts
@@ -1,6 +1,48 @@
-import { BigInt, ethereum } from "@graphprotocol/graph-ts";
+import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { OrderCreated, OrderDeleted, OrderExecuted } from "../../generated/BullaSwap/BullaSwap";
-import { OrderCreatedEvent, OrderDeletedEvent, OrderExecutedEvent } from "../../generated/schema";
+import { OrderCreatedEvent, OrderDeletedEvent, OrderERC20, OrderExecutedEvent } from "../../generated/schema";
+import { getOrCreateToken } from "./common";
+
+export const SWAP_ORDER_STATUS_PENDING = "Pending";
+export const SWAP_ORDER_STATUS_EXECUTED = "Executed";
+export const SWAP_ORDER_STATUS_CANCELED = "Canceled";
+
+// Load the lifecycle order (or create it, defaulting to Pending), then refresh
+// its terms and the latest-touched transaction metadata. createdAt is only set
+// when the entity is first materialized. Terms are passed as scalars because
+// AssemblyScript has no union type to accept the three distinct *OrderStruct
+// classes the three swap events generate.
+export const getOrCreateOrder = (
+  orderId: BigInt,
+  expiry: BigInt,
+  signerWallet: Address,
+  signerToken: Address,
+  signerAmount: BigInt,
+  senderWallet: Address,
+  senderToken: Address,
+  senderAmount: BigInt,
+  event: ethereum.Event,
+): OrderERC20 => {
+  const id = orderId.toString();
+  let order = OrderERC20.load(id);
+  if (order == null) {
+    order = new OrderERC20(id);
+    order.orderId = orderId;
+    order.status = SWAP_ORDER_STATUS_PENDING;
+    order.createdAt = event.block.timestamp;
+  }
+  order.expiry = expiry;
+  order.signerWallet = signerWallet;
+  order.signerToken = getOrCreateToken(signerToken).id;
+  order.signerAmount = signerAmount;
+  order.senderWallet = senderWallet;
+  order.senderToken = getOrCreateToken(senderToken).id;
+  order.senderAmount = senderAmount;
+  order.transactionHash = event.transaction.hash;
+  order.lastUpdatedBlock = event.block.number;
+  order.lastUpdatedTimestamp = event.block.timestamp;
+  return order;
+};
 
 export const getOrderCreatedEventId = (orderId: BigInt, event: ethereum.Event): string =>
   "OrderCreated-" + orderId.toString() + "-" + event.transaction.hash.toHexString() + "-" + event.logIndex.toString();

--- a/bulla-contracts/src/functions/common.ts
+++ b/bulla-contracts/src/functions/common.ts
@@ -8,6 +8,7 @@ import { BullaManager as BullaManagerContract } from "../../generated/BullaManag
 import { LoanOfferedLoanOfferAttachmentStruct } from "../../generated/FrendLend/FrendLend";
 import {
   BullaManager,
+  BullaTransaction,
   ClaimFinancing,
   FactoringPool,
   FactoringPoolStats,
@@ -118,6 +119,20 @@ export const getOrCreateUser = (address: Address): User => {
   }
 
   return user;
+};
+
+export const getOrCreateBullaTransaction = (event: ethereum.Event): BullaTransaction => {
+  const id = event.transaction.hash.toHexString();
+  let bullaTransaction = BullaTransaction.load(id);
+  if (!bullaTransaction) {
+    bullaTransaction = new BullaTransaction(id);
+    bullaTransaction.txHash = event.transaction.hash;
+    bullaTransaction.user = getOrCreateUser(event.transaction.from).id;
+    bullaTransaction.timestamp = event.block.timestamp;
+    bullaTransaction.save();
+  }
+
+  return bullaTransaction;
 };
 
 // Mirrors the client's getPayables/getReceivables open-status filter:

--- a/bulla-contracts/src/functions/common.ts
+++ b/bulla-contracts/src/functions/common.ts
@@ -8,6 +8,7 @@ import { BullaManager as BullaManagerContract } from "../../generated/BullaManag
 import { LoanOfferedLoanOfferAttachmentStruct } from "../../generated/FrendLend/FrendLend";
 import {
   BullaManager,
+  ClaimFinancing,
   FactoringPool,
   FactoringPoolStats,
   FactoringPricePerShare,
@@ -15,6 +16,7 @@ import {
   FactoringStatisticEntry,
   FactoringStatisticsEntry,
   HistoricalFactoringStatistics,
+  LoanOffer,
   PnlHistoryEntry,
   PoolPnl,
   PriceHistoryEntry,
@@ -547,6 +549,56 @@ export const getTargetFeesAndTaxes = (poolAddress: Address, version: string, inv
   const grossInterest = protocolPlusGrossInterest.minus(protocolFee);
   const tax = calculateTax(poolAddress, version, grossInterest);
   return [grossInterest, protocolFee, adminFee, tax];
+};
+
+// ============================================================================
+// ClaimFinancing — denormalized frendlend / vendor-financing state.
+// ============================================================================
+
+export const CLAIM_FINANCING_KIND_OFFERED = "Offered";
+export const CLAIM_FINANCING_KIND_ACCEPTED = "Accepted";
+
+export const CLAIM_FINANCING_ORIGINATION_FRENDLEND = "FrendLend";
+export const CLAIM_FINANCING_ORIGINATION_VENDOR = "VendorFinancing";
+
+export const getOrCreateClaimFinancing = (claimId: string, event: ethereum.Event): ClaimFinancing => {
+  let financing = ClaimFinancing.load(claimId);
+  if (!financing) {
+    financing = new ClaimFinancing(claimId);
+    financing.claim = claimId;
+    financing.totalGrossInterestPaid = BigInt.fromI32(0);
+    financing.totalPrincipalPaid = BigInt.fromI32(0);
+    financing.totalProtocolFee = BigInt.fromI32(0);
+    financing.paymentCount = BigInt.fromI32(0);
+  }
+  financing.lastUpdatedTimestamp = event.block.timestamp;
+  financing.lastUpdatedBlock = event.block.number;
+  return financing;
+};
+
+// ============================================================================
+// LoanOffer — denormalized frendlend offer lifecycle, keyed by loanId-version.
+// ============================================================================
+
+export const LOAN_OFFER_STATUS_OFFERED = "Offered";
+export const LOAN_OFFER_STATUS_REJECTED = "Rejected";
+export const LOAN_OFFER_STATUS_ACCEPTED = "Accepted";
+
+export const getLoanOfferId = (loanId: string, version: string): string => loanId + "-" + version;
+
+export const getOrCreateLoanOffer = (loanId: string, version: string, event: ethereum.Event): LoanOffer => {
+  const id = getLoanOfferId(loanId, version);
+  let offer = LoanOffer.load(id);
+  if (!offer) {
+    offer = new LoanOffer(id);
+    offer.loanId = loanId;
+    offer.principalPaid = BigInt.fromI32(0);
+    offer.grossInterestPaid = BigInt.fromI32(0);
+    offer.protocolFee = BigInt.fromI32(0);
+  }
+  offer.lastUpdatedTimestamp = event.block.timestamp;
+  offer.lastUpdatedBlock = event.block.number;
+  return offer;
 };
 
 // For compatibility with InvoiceReconciled for v0 fees

--- a/bulla-contracts/src/mappings/BullaBanker.ts
+++ b/bulla-contracts/src/mappings/BullaBanker.ts
@@ -8,9 +8,10 @@ import {
   getOrCreateBullaTagUpdatedEvent,
 } from "../functions/BullaBanker";
 import { isClaimIncompleteV1, tryGetClaim } from "../functions/BullaClaimERC721";
-import { BULLA_CLAIM_VERSION_V1 } from "../functions/common";
+import { BULLA_CLAIM_VERSION_V1, getOrCreateBullaTransaction } from "../functions/common";
 
 export function handleBullaTagUpdated(event: BullaTagUpdated): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const tag = ev.tag.toString();
   const tokenId = ev.tokenId.toString();
@@ -68,6 +69,7 @@ export function handleBullaTagUpdated(event: BullaTagUpdated): void {
 }
 
 export function handleBullaBankerCreated(event: BullaBankerCreated): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const bullaBankerCreatedEvent = createBullaBankerCreatedEvent(event);
 

--- a/bulla-contracts/src/mappings/BullaBankerModule.ts
+++ b/bulla-contracts/src/mappings/BullaBankerModule.ts
@@ -1,9 +1,10 @@
 import { BullaBankerModuleDeploy } from "../../generated/BullaBankerModule/BullaBankerModule";
 import { BullaBankerGnosisModuleConfig } from "../../generated/schema";
 import { getGnosisModuleConfigId } from "../functions/BullaBankerModule";
-import { getOrCreateUser } from "../functions/common";
+import { getOrCreateUser, getOrCreateBullaTransaction } from "../functions/common";
 
 export function handleBullaBankerModuleDeploy(event: BullaBankerModuleDeploy): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const safeUser = getOrCreateUser(ev.safe);
 

--- a/bulla-contracts/src/mappings/BullaClaimERC721.ts
+++ b/bulla-contracts/src/mappings/BullaClaimERC721.ts
@@ -303,6 +303,7 @@ export function handleClaimPayment(event: ClaimPaymentV1): void {
   const wasOpen = isOpenClaimStatus(claim.status);
   claim.paidAmount = totalPaidAmount;
   claim.status = isClaimPaid ? CLAIM_STATUS_PAID : CLAIM_STATUS_REPAYING;
+  claim.lastPaymentDate = event.block.timestamp;
   claim.lastUpdatedBlockNumber = event.block.number;
   claim.lastUpdatedTimestamp = event.block.timestamp;
   claim.save();
@@ -335,6 +336,7 @@ export function handleClaimPaymentV2(event: ClaimPaymentV2): void {
   const wasOpen = isOpenClaimStatus(claim.status);
   claim.paidAmount = ev.totalPaidAmount;
   claim.status = isClaimPaid ? CLAIM_STATUS_PAID : CLAIM_STATUS_REPAYING;
+  claim.lastPaymentDate = event.block.timestamp;
   claim.lastUpdatedBlockNumber = event.block.number;
   claim.lastUpdatedTimestamp = event.block.timestamp;
   claim.save();
@@ -374,6 +376,7 @@ export function handleClaimCreatedV1(event: ClaimCreatedV1): void {
   claim.creator = user_creator.id;
   claim.creditor = user_creditor.id;
   claim.debtor = user_debtor.id;
+  claim.originalCreditor = ev.creditor; // creditor at creation, never mutated by transfers
   claim.amount = ev.claim.claimAmount;
   claim.paidAmount = ev.claim.paidAmount;
   claim.isTransferred = false;
@@ -385,6 +388,7 @@ export function handleClaimCreatedV1(event: ClaimCreatedV1): void {
   claim.status = CLAIM_STATUS_PENDING;
   claim.controller = user_nullController.id; // null id, as no controller in v1
   claim.binding = CLAIM_BINDING_UNBOUND; // no binding in v1
+  claim.impairmentGracePeriod = BigInt.fromI32(0); // no impairment grace period in v1; populated for parity across chains
   claim.transactionHash = event.transaction.hash;
   claim.lastUpdatedBlockNumber = event.block.number;
   claim.lastUpdatedTimestamp = event.block.timestamp;
@@ -445,6 +449,7 @@ export function handleClaimCreatedV2(event: ClaimCreatedV2): void {
   claim.creditor = user_creditor.id;
   claim.debtor = user_debtor.id;
   claim.controller = user_controller.id;
+  claim.originalCreditor = ev.creditor; // creditor at creation, never mutated by transfers
 
   claim.amount = ev.claimAmount;
   claim.paidAmount = BigInt.fromI32(0);

--- a/bulla-contracts/src/mappings/BullaClaimERC721.ts
+++ b/bulla-contracts/src/mappings/BullaClaimERC721.ts
@@ -59,8 +59,7 @@ import {
   getIPFSHash_claimCreated,
   getOrCreateToken,
   getOrCreateUser,
-  isOpenClaimStatus,
-} from "../functions/common";
+  isOpenClaimStatus, getOrCreateBullaTransaction,} from "../functions/common";
 
 function logEventOrder(eventName: string, version: string, tokenId: string, event: ethereum.Event): void {
   const claimId = tokenId + "-" + version;
@@ -89,6 +88,7 @@ function logV1ClaimSkip(handler: string, tokenId: string, reason: string, event:
 }
 
 export function handleTransferV1(event: ERC721TransferEvent): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const transferId = getTransferEventId(event.params.tokenId, event);
   const tokenId = ev.tokenId.toString();
@@ -138,6 +138,7 @@ export function handleTransferV1(event: ERC721TransferEvent): void {
 }
 
 export function handleTransferV2(event: ERC721TransferEvent): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const transferId = getTransferEventId(event.params.tokenId, event);
   const tokenId = ev.tokenId.toString();
@@ -178,6 +179,7 @@ export function handleTransferV2(event: ERC721TransferEvent): void {
 }
 
 export function handleFeePaid(event: FeePaid): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const feePaidEventId = getFeePaidEventId(event.params.tokenId, event);
   const tokenId = ev.tokenId.toString();
@@ -198,6 +200,7 @@ export function handleFeePaid(event: FeePaid): void {
 }
 
 export function handleClaimRescinded(event: ClaimRescinded): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const tokenId = ev.tokenId.toString();
   logEventOrder("ClaimRescinded", "v1", tokenId, event);
@@ -233,6 +236,7 @@ export function handleClaimRescinded(event: ClaimRescinded): void {
 }
 
 export function handleClaimRejected(event: ClaimRejected): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const tokenId = ev.tokenId.toString();
   logEventOrder("ClaimRejected", "v1", tokenId, event);
@@ -268,6 +272,7 @@ export function handleClaimRejected(event: ClaimRejected): void {
 }
 
 export function handleClaimPayment(event: ClaimPaymentV1): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const tokenId = ev.tokenId.toString();
   logEventOrder("ClaimPayment", "v1", tokenId, event);
@@ -311,6 +316,7 @@ export function handleClaimPayment(event: ClaimPaymentV1): void {
 }
 
 export function handleClaimPaymentV2(event: ClaimPaymentV2): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   logEventOrder("ClaimPayment", "v2", ev.claimId.toString(), event);
   const claimPaymentEventId = getClaimPaymentEventId(event.params.claimId, event);
@@ -344,6 +350,7 @@ export function handleClaimPaymentV2(event: ClaimPaymentV2): void {
 }
 
 export function handleBullaManagerSetEvent(event: BullaManagerSet): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const bullaManagerSetEvent = createBullaManagerSet(event);
   bullaManagerSetEvent.prevBullaManager = ev.prevBullaManager;
@@ -358,6 +365,7 @@ export function handleBullaManagerSetEvent(event: BullaManagerSet): void {
 }
 
 export function handleClaimCreatedV1(event: ClaimCreatedV1): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   logEventOrder("ClaimCreated", "v1", ev.tokenId.toString(), event);
   const token = getOrCreateToken(ev.claim.claimToken);
@@ -432,6 +440,7 @@ export function handleClaimCreatedV1(event: ClaimCreatedV1): void {
 }
 
 export function handleClaimCreatedV2(event: ClaimCreatedV2): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   logEventOrder("ClaimCreated", "v2", ev.claimId.toString(), event);
   const token = getOrCreateToken(ev.token);
@@ -517,6 +526,7 @@ export function handleClaimCreatedV2(event: ClaimCreatedV2): void {
 }
 
 export function handleMetadataAdded(event: MetadataAdded): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const tokenId = ev.claimId.toString();
   const claim = getOrCreateClaim(tokenId, BULLA_CLAIM_VERSION_V2);
@@ -541,6 +551,7 @@ export function handleMetadataAdded(event: MetadataAdded): void {
 }
 
 export function handleBindingUpdated(event: BindingUpdated): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const tokenId = ev.claimId.toString();
   logEventOrder("BindingUpdated", "v2", tokenId, event);
@@ -565,6 +576,7 @@ export function handleBindingUpdated(event: BindingUpdated): void {
 }
 
 export function handleClaimRejectedV2(event: ClaimRejectedV2): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const tokenId = ev.claimId.toString();
   logEventOrder("ClaimRejected", "v2", tokenId, event);
@@ -592,6 +604,7 @@ export function handleClaimRejectedV2(event: ClaimRejectedV2): void {
 }
 
 export function handleClaimRescindedV2(event: ClaimRescindedV2): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const tokenId = ev.claimId.toString();
   logEventOrder("ClaimRescinded", "v2", tokenId, event);
@@ -619,6 +632,7 @@ export function handleClaimRescindedV2(event: ClaimRescindedV2): void {
 }
 
 export function handleClaimImpaired(event: ClaimImpaired): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const tokenId = ev.claimId.toString();
   logEventOrder("ClaimImpaired", "v2", tokenId, event);
@@ -643,6 +657,7 @@ export function handleClaimImpaired(event: ClaimImpaired): void {
 }
 
 export function handleClaimMarkedAsPaid(event: ClaimMarkedAsPaid): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const tokenId = ev.claimId.toString();
   logEventOrder("ClaimMarkedAsPaid", "v2", tokenId, event);

--- a/bulla-contracts/src/mappings/BullaFactoring.ts
+++ b/bulla-contracts/src/mappings/BullaFactoring.ts
@@ -94,8 +94,7 @@ import {
   getOrCreateUser,
   getPriceBeforeTransaction,
   getTargetFeesAndTaxes,
-  getTrueFeesAndTaxesV0,
-} from "../functions/common";
+  getTrueFeesAndTaxesV0, getOrCreateBullaTransaction,} from "../functions/common";
 
 // ============================================================================
 // InvoiceFunded
@@ -183,10 +182,12 @@ function handleInvoiceFunded(event: InvoiceFundedV1, version: string): void {
 }
 
 export function handleInvoiceFundedV0(event: InvoiceFundedV1): void {
+  getOrCreateBullaTransaction(event);
   handleInvoiceFunded(event, "v0");
 }
 
 export function handleInvoiceFundedV1(event: InvoiceFundedV1): void {
+  getOrCreateBullaTransaction(event);
   handleInvoiceFunded(event, "v1");
 }
 
@@ -259,6 +260,7 @@ function handleInvoiceFundedV2_1or2(event: InvoiceFundedV2_1, version: string): 
 }
 
 export function handleInvoiceFundedV2_1(event: InvoiceFundedV2_1): void {
+  getOrCreateBullaTransaction(event);
   handleInvoiceFundedV2_1or2(event, "v2_1");
 }
 
@@ -316,14 +318,17 @@ function handleInvoiceKickbackAmountSent(event: InvoiceKickbackAmountSentV2_1, v
 }
 
 export function handleInvoiceKickbackAmountSentV0(event: InvoiceKickbackAmountSentV0): void {
+  getOrCreateBullaTransaction(event);
   handleInvoiceKickbackAmountSent(changetype<InvoiceKickbackAmountSentV2_1>(event), "v0");
 }
 
 export function handleInvoiceKickbackAmountSentV1(event: InvoiceKickbackAmountSentV1): void {
+  getOrCreateBullaTransaction(event);
   handleInvoiceKickbackAmountSent(changetype<InvoiceKickbackAmountSentV2_1>(event), "v1");
 }
 
 export function handleInvoiceKickbackAmountSentV2_1(event: InvoiceKickbackAmountSentV2_1): void {
+  getOrCreateBullaTransaction(event);
   handleInvoiceKickbackAmountSent(event, "v2_1");
 }
 
@@ -333,6 +338,7 @@ export function handleInvoiceKickbackAmountSentV2_1(event: InvoiceKickbackAmount
 
 // V0: ActivePaidInvoicesReconciled (batch event)
 export function handleActivePaidInvoicesReconciledV0(event: ActivePaidInvoicesReconciled): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   let pnlTotal = BigInt.fromI32(0);
   const pool = getOrCreateUser(event.address);
@@ -413,6 +419,7 @@ export function handleActivePaidInvoicesReconciledV0(event: ActivePaidInvoicesRe
 
 // V1: InvoicePaid
 export function handleInvoicePaidV1(event: InvoicePaidV1): void {
+  getOrCreateBullaTransaction(event);
   const ev: InvoicePaid__Params = event.params;
   const originatingClaimId = ev.invoiceId;
 
@@ -545,6 +552,7 @@ function handleInvoicePaidV2_1or2(event: InvoicePaidV2_1, version: string): void
 }
 
 export function handleInvoicePaidV2_1(event: InvoicePaidV2_1): void {
+  getOrCreateBullaTransaction(event);
   handleInvoicePaidV2_1or2(event, "v2_1");
 }
 
@@ -554,6 +562,7 @@ export function handleInvoicePaidV2_1(event: InvoicePaidV2_1): void {
 
 // V0: InvoiceUnfactored(indexed uint256,address,uint256,uint256)
 export function handleInvoiceUnfactoredV0(event: InvoiceUnfactoredV0): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const originatingClaimId = ev.invoiceId;
 
@@ -614,6 +623,7 @@ export function handleInvoiceUnfactoredV0(event: InvoiceUnfactoredV0): void {
 
 // V1: InvoiceUnfactored(indexed uint256,address,int256,uint256)
 export function handleInvoiceUnfactoredV1(event: InvoiceUnfactoredV1): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const originatingClaimId = ev.invoiceId;
 
@@ -743,6 +753,7 @@ function handleInvoiceUnfactoredV2_1or2(event: InvoiceUnfactoredV2_1, version: s
 }
 
 export function handleInvoiceUnfactoredV2_1(event: InvoiceUnfactoredV2_1): void {
+  getOrCreateBullaTransaction(event);
   handleInvoiceUnfactoredV2_1or2(event, "v2_1");
 }
 
@@ -752,6 +763,7 @@ export function handleInvoiceUnfactoredV2_1(event: InvoiceUnfactoredV2_1): void 
 
 // V0: DepositMade(indexed address,uint256,uint256)
 export function handleDepositMadeV0(event: DepositMade): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
 
   // Create FactoringPool entity if it doesn't exist (for pools not created via factory)
@@ -841,10 +853,12 @@ function handleDeposit(event: DepositV1, version: string): void {
 }
 
 export function handleDepositV1(event: DepositV1): void {
+  getOrCreateBullaTransaction(event);
   handleDeposit(event, "v1");
 }
 
 export function handleDepositV2_1(event: DepositV2_1): void {
+  getOrCreateBullaTransaction(event);
   handleDeposit(changetype<DepositV1>(event), "v2_1");
 }
 
@@ -854,6 +868,7 @@ export function handleDepositV2_1(event: DepositV2_1): void {
 
 // V0: SharesRedeemed(indexed address,uint256,uint256)
 export function handleSharesRedeemedV0(event: SharesRedeemed): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
 
   const SharesRedeemedEvent = createSharesRedeemedEventV0(event);
@@ -929,10 +944,12 @@ function handleWithdraw(event: WithdrawV1, version: string): void {
 }
 
 export function handleWithdrawV1(event: WithdrawV1): void {
+  getOrCreateBullaTransaction(event);
   handleWithdraw(event, "v1");
 }
 
 export function handleWithdrawV2_1(event: WithdrawV2_1): void {
+  getOrCreateBullaTransaction(event);
   handleWithdraw(changetype<WithdrawV1>(event), "v2_1");
 }
 
@@ -985,10 +1002,12 @@ function handleInvoiceImpaired(event: InvoiceImpaired, version: string): void {
 }
 
 export function handleInvoiceImpairedV0(event: InvoiceImpaired): void {
+  getOrCreateBullaTransaction(event);
   handleInvoiceImpaired(event, "v0");
 }
 
 export function handleInvoiceImpairedV1(event: InvoiceImpaired): void {
+  getOrCreateBullaTransaction(event);
   handleInvoiceImpaired(event, "v1");
 }
 
@@ -1004,6 +1023,7 @@ export function handleInvoiceImpairedV1(event: InvoiceImpaired): void {
 // the frontend needs the pre-fees value. V2_1 doesn't emit InvoiceImpaired
 // at all — gap documented in the schema comment.
 export function handleInvoiceImpairedV2_2(event: InvoiceImpairedV2_2): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const originatingClaimId = ev.invoiceId;
 
@@ -1047,18 +1067,21 @@ export function handleInvoiceImpairedV2_2(event: InvoiceImpairedV2_2): void {
 // ============================================================================
 
 export function handleDepositPermissionsChangedV0(event: DepositPermissionsChangedV0): void {
+  getOrCreateBullaTransaction(event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v0");
   poolPermissions.depositPermissions = event.params.newAddress;
   poolPermissions.save();
 }
 
 export function handleDepositPermissionsChangedV1(event: DepositPermissionsChangedV1): void {
+  getOrCreateBullaTransaction(event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v1");
   poolPermissions.depositPermissions = event.params.newAddress;
   poolPermissions.save();
 }
 
 export function handleDepositPermissionsChangedV2_1(event: DepositPermissionsChangedV2_1): void {
+  getOrCreateBullaTransaction(event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v2_1");
   poolPermissions.depositPermissions = event.params.newAddress;
   poolPermissions.save();
@@ -1069,18 +1092,21 @@ export function handleDepositPermissionsChangedV2_1(event: DepositPermissionsCha
 // ============================================================================
 
 export function handleFactoringPermissionsChangedV0(event: FactoringPermissionsChangedV0): void {
+  getOrCreateBullaTransaction(event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v0");
   poolPermissions.factoringPermissions = event.params.newAddress;
   poolPermissions.save();
 }
 
 export function handleFactoringPermissionsChangedV1(event: FactoringPermissionsChangedV1): void {
+  getOrCreateBullaTransaction(event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v1");
   poolPermissions.factoringPermissions = event.params.newAddress;
   poolPermissions.save();
 }
 
 export function handleFactoringPermissionsChangedV2_1(event: FactoringPermissionsChangedV2_1): void {
+  getOrCreateBullaTransaction(event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v2_1");
   poolPermissions.factoringPermissions = event.params.newAddress;
   poolPermissions.save();
@@ -1091,6 +1117,7 @@ export function handleFactoringPermissionsChangedV2_1(event: FactoringPermission
 // ============================================================================
 
 export function handleRedeemPermissionsChangedV2_1(event: RedeemPermissionsChangedV2_1): void {
+  getOrCreateBullaTransaction(event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v2_1");
   poolPermissions.redeemPermissions = event.params.newAddress;
   poolPermissions.save();
@@ -1141,6 +1168,7 @@ function handleInvoiceApprovedV2_1or2(event: InvoiceApprovedV2_1, version: strin
 }
 
 export function handleInvoiceApprovedV2_1(event: InvoiceApprovedV2_1): void {
+  getOrCreateBullaTransaction(event);
   handleInvoiceApprovedV2_1or2(event, "v2_1");
 }
 
@@ -1150,48 +1178,58 @@ export function handleInvoiceApprovedV2_1(event: InvoiceApprovedV2_1): void {
 
 // Shared events (same signature as V2_1): delegate via changetype
 export function handleInvoiceFundedV2_2(event: InvoiceFundedV2_2): void {
+  getOrCreateBullaTransaction(event);
   handleInvoiceFundedV2_1or2(changetype<InvoiceFundedV2_1>(event), "v2_2");
 }
 
 export function handleInvoiceKickbackAmountSentV2_2(event: InvoiceKickbackAmountSentV2_1): void {
+  getOrCreateBullaTransaction(event);
   handleInvoiceKickbackAmountSent(event, "v2_2");
 }
 
 export function handleInvoicePaidV2_2(event: InvoicePaidV2_2): void {
+  getOrCreateBullaTransaction(event);
   handleInvoicePaidV2_1or2(changetype<InvoicePaidV2_1>(event), "v2_2");
 }
 
 export function handleInvoiceUnfactoredV2_2(event: InvoiceUnfactoredV2_2): void {
+  getOrCreateBullaTransaction(event);
   handleInvoiceUnfactoredV2_1or2(changetype<InvoiceUnfactoredV2_1>(event), "v2_2");
 }
 
 export function handleDepositV2_2(event: DepositV2_2): void {
+  getOrCreateBullaTransaction(event);
   handleDeposit(changetype<DepositV1>(event), "v2_2");
 }
 
 export function handleWithdrawV2_2(event: WithdrawV2_2): void {
+  getOrCreateBullaTransaction(event);
   handleWithdraw(changetype<WithdrawV1>(event), "v2_2");
 }
 
 export function handleDepositPermissionsChangedV2_2(event: DepositPermissionsChangedV2_2): void {
+  getOrCreateBullaTransaction(event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v2_2");
   poolPermissions.depositPermissions = event.params.newAddress;
   poolPermissions.save();
 }
 
 export function handleFactoringPermissionsChangedV2_2(event: FactoringPermissionsChangedV2_2): void {
+  getOrCreateBullaTransaction(event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v2_2");
   poolPermissions.factoringPermissions = event.params.newAddress;
   poolPermissions.save();
 }
 
 export function handleRedeemPermissionsChangedV2_2(event: RedeemPermissionsChangedV2_2): void {
+  getOrCreateBullaTransaction(event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v2_2");
   poolPermissions.redeemPermissions = event.params.newAddress;
   poolPermissions.save();
 }
 
 export function handleInvoiceApprovedV2_2(event: InvoiceApprovedV2_2): void {
+  getOrCreateBullaTransaction(event);
   handleInvoiceApprovedV2_1or2(changetype<InvoiceApprovedV2_1>(event), "v2_2");
 }
 

--- a/bulla-contracts/src/mappings/BullaFactoringFactory.ts
+++ b/bulla-contracts/src/mappings/BullaFactoringFactory.ts
@@ -1,9 +1,10 @@
 import { PoolCreated } from "../../generated/BullaFactoringFactoryV2_1/BullaFactoringFactoryV2_1";
 import { BullaFactoringV2_1Pool } from "../../generated/templates";
 import { PoolCreatedEvent, FactoringPool } from "../../generated/schema";
-import { getOrCreateUser } from "../functions/common";
+import { getOrCreateUser, getOrCreateBullaTransaction } from "../functions/common";
 
 export function handlePoolCreated(event: PoolCreated): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
 
   // Create the dynamic data source for the new pool

--- a/bulla-contracts/src/mappings/BullaFinance.ts
+++ b/bulla-contracts/src/mappings/BullaFinance.ts
@@ -8,16 +8,17 @@ import {
   CLAIM_FINANCING_KIND_OFFERED,
   CLAIM_FINANCING_ORIGINATION_VENDOR,
   getOrCreateClaimFinancing,
-  getOrCreateUser,
-} from "../functions/common";
+  getOrCreateUser, getOrCreateBullaTransaction,} from "../functions/common";
 import * as BullaBanker from "./BullaBanker";
 
 // this contract also emits BullaTagUpdatedEvents
 export function handleBullaTagUpdated(event: BullaTagUpdated): void {
+  getOrCreateBullaTransaction(event);
   BullaBanker.handleBullaTagUpdated(event);
 }
 
 export function handleFinancingOffered(event: FinancingOffered): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const originatingClaimId = ev.originatingClaimId;
 
@@ -60,6 +61,7 @@ export function handleFinancingOffered(event: FinancingOffered): void {
 }
 
 export function handleFinancingAccepted(event: FinancingAccepted): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const originatingClaimId = ev.originatingClaimId;
   const financedClaimId = ev.financedClaimId;

--- a/bulla-contracts/src/mappings/BullaFinance.ts
+++ b/bulla-contracts/src/mappings/BullaFinance.ts
@@ -3,7 +3,13 @@ import { BullaTagUpdated } from "../../generated/BullaBanker/BullaBanker";
 import { FinancingAccepted, FinancingOffered } from "../../generated/BullaFinance/BullaFinance";
 import { getClaim } from "../functions/BullaClaimERC721";
 import { createFinancingAcceptedEvent, createFinancingOfferedEvent } from "../functions/BullaFinance";
-import { getOrCreateUser } from "../functions/common";
+import {
+  CLAIM_FINANCING_KIND_ACCEPTED,
+  CLAIM_FINANCING_KIND_OFFERED,
+  CLAIM_FINANCING_ORIGINATION_VENDOR,
+  getOrCreateClaimFinancing,
+  getOrCreateUser,
+} from "../functions/common";
 import * as BullaBanker from "./BullaBanker";
 
 // this contract also emits BullaTagUpdatedEvents
@@ -31,6 +37,15 @@ export function handleFinancingOffered(event: FinancingOffered): void {
   financingOfferedEvent.transactionHash = event.transaction.hash;
   financingOfferedEvent.logIndex = event.logIndex;
   financingOfferedEvent.timestamp = event.block.timestamp;
+
+  const financing = getOrCreateClaimFinancing(underlyingClaim.id, event);
+  financing.kind = CLAIM_FINANCING_KIND_OFFERED;
+  financing.origination = CLAIM_FINANCING_ORIGINATION_VENDOR;
+  financing.minDownPaymentBps = ev.terms.minDownPaymentBPS;
+  financing.interestBps = ev.terms.interestBPS;
+  financing.termLength = ev.terms.termLength;
+  financing.save();
+  underlyingClaim.financing = financing.id;
 
   underlyingClaim.lastUpdatedBlockNumber = event.block.number;
   underlyingClaim.lastUpdatedTimestamp = event.block.timestamp;
@@ -64,6 +79,13 @@ export function handleFinancingAccepted(event: FinancingAccepted): void {
   financingAcceptedEvent.transactionHash = event.transaction.hash;
   financingAcceptedEvent.logIndex = event.logIndex;
   financingAcceptedEvent.timestamp = event.block.timestamp;
+
+  const financing = getOrCreateClaimFinancing(financedClaim.id, event);
+  financing.kind = CLAIM_FINANCING_KIND_ACCEPTED;
+  financing.origination = CLAIM_FINANCING_ORIGINATION_VENDOR;
+  financing.originatingTokenId = originatingClaimId.toString();
+  financing.save();
+  financedClaim.financing = financing.id;
 
   originatingClaim.lastUpdatedBlockNumber = event.block.number;
   originatingClaim.lastUpdatedTimestamp = event.block.timestamp;

--- a/bulla-contracts/src/mappings/BullaInstantPayment.ts
+++ b/bulla-contracts/src/mappings/BullaInstantPayment.ts
@@ -17,6 +17,8 @@ export function handleInstantPayment(event: InstantPayment): void {
   instantPayment.token = token.id;
   instantPayment.description = event.params.description;
   instantPayment.ipfsHash = event.params.ipfsHash === "" ? null : event.params.ipfsHash;
+  instantPayment.createdAt = event.block.timestamp;
+  instantPayment.transactionHash = event.transaction.hash;
   instantPayment.save();
 
   const instantPaymentTag = new InstantPaymentTag(instantPaymentId);

--- a/bulla-contracts/src/mappings/BullaInstantPayment.ts
+++ b/bulla-contracts/src/mappings/BullaInstantPayment.ts
@@ -1,9 +1,10 @@
 import { InstantPaymentEvent, InstantPaymentTag, InstantPayment as InstantPayment__entity, InstantPaymentTagUpdatedEvent } from "../../generated/schema";
 import { InstantPayment, InstantPaymentTagUpdated } from "../../generated/BullaInstantPayment/BullaInstantPayment";
 import { getInstantPaymentEventId, getInstantPaymentTagUpdatedId } from "../functions/BullaInstantPayment";
-import { getOrCreateToken, getOrCreateUser, hexStringToLowercase } from "../functions/common";
+import { getOrCreateToken, getOrCreateUser, hexStringToLowercase, getOrCreateBullaTransaction } from "../functions/common";
 
 export function handleInstantPayment(event: InstantPayment): void {
+  getOrCreateBullaTransaction(event);
   const token = getOrCreateToken(event.params.tokenAddress);
   const instantPaymentId = getInstantPaymentEventId(event.transaction.hash, event.logIndex);
   const user_from = getOrCreateUser(event.params.from);
@@ -52,6 +53,7 @@ export function handleInstantPayment(event: InstantPayment): void {
 }
 
 export function handleInstantPaymentTagUpdated(event: InstantPaymentTagUpdated): void {
+  getOrCreateBullaTransaction(event);
   const instantPaymentId: string = hexStringToLowercase(event.params.txAndLogIndexHash.toHexString());
   const instantPaymentEvent = InstantPaymentEvent.load(instantPaymentId);
 

--- a/bulla-contracts/src/mappings/BullaInvoice.ts
+++ b/bulla-contracts/src/mappings/BullaInvoice.ts
@@ -12,9 +12,10 @@ import {
   getPurchaseOrderDeliveredEventId,
   getPurchaseOrderState,
 } from "../functions/BullaInvoice";
-import { getOrCreateToken, getOrCreateUser } from "../functions/common";
+import { getOrCreateToken, getOrCreateUser, getOrCreateBullaTransaction } from "../functions/common";
 
 export function handleInvoiceCreated(event: InvoiceCreated): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const claimId = ev.claimId.toString();
   // Add the invoice created event to creditor and debtor's invoiceEvents
@@ -82,6 +83,7 @@ export function handleInvoiceCreated(event: InvoiceCreated): void {
 }
 
 export function handleInvoicePaid(event: InvoicePaid): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const invoicePaidEvent = createInvoicePaidEvent(event);
   const claim = getOrCreateClaim(ev.claimId.toString(), "v2");
@@ -114,6 +116,7 @@ export function handleInvoicePaid(event: InvoicePaid): void {
 }
 
 export function handlePurchaseOrderAccepted(event: PurchaseOrderAccepted): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const claimId = ev.claimId.toString();
 
@@ -160,6 +163,7 @@ export function handlePurchaseOrderAccepted(event: PurchaseOrderAccepted): void 
 }
 
 export function handlePurchaseOrderDelivered(event: PurchaseOrderDelivered): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const claimId = ev.claimId.toString();
 
@@ -206,6 +210,7 @@ export function handlePurchaseOrderDelivered(event: PurchaseOrderDelivered): voi
 }
 
 export function handleFeeWithdrawn(event: FeeWithdrawn): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
 
   // Create the FeeWithdrawnEvent

--- a/bulla-contracts/src/mappings/BullaInvoice.ts
+++ b/bulla-contracts/src/mappings/BullaInvoice.ts
@@ -8,6 +8,7 @@ import {
   createInvoicePaidEvent,
   createPurchaseOrderAcceptedEvent,
   createPurchaseOrderStateFromEvent,
+  getOrCreateInvoiceDetails,
   getPurchaseOrderDeliveredEventId,
   getPurchaseOrderState,
 } from "../functions/BullaInvoice";
@@ -53,6 +54,23 @@ export function handleInvoiceCreated(event: InvoiceCreated): void {
   invoiceCreatedEvent.timestamp = event.block.timestamp;
   invoiceCreatedEvent.save();
 
+  const invoiceDetailsEntity = getOrCreateInvoiceDetails(claim.id, event);
+  invoiceDetailsEntity.deliveryDate = purchaseOrder.deliveryDate;
+  invoiceDetailsEntity.depositAmount = purchaseOrder.depositAmount;
+  invoiceDetailsEntity.interestRateBps = lateFeeConfig.interestRateBps;
+  invoiceDetailsEntity.numberOfPeriodsPerYear = lateFeeConfig.numberOfPeriodsPerYear;
+  invoiceDetailsEntity.isDelivered = purchaseOrder.isDelivered;
+  invoiceDetailsEntity.requestedByCreditor = invoiceDetails.requestedByCreditor;
+  invoiceDetailsEntity.isProtocolFeeExempt = invoiceDetails.isProtocolFeeExempt;
+  invoiceDetailsEntity.attachmentURI = ev.metadata.attachmentURI;
+  invoiceDetailsEntity.tokenURI = ev.metadata.tokenURI;
+  invoiceDetailsEntity.save();
+
+  claim.invoiceDetails = invoiceDetailsEntity.id;
+  claim.lastUpdatedBlockNumber = event.block.number;
+  claim.lastUpdatedTimestamp = event.block.timestamp;
+  claim.save();
+
   const user_creditor = getOrCreateUser(Address.fromString(claim.creditor));
   const user_debtor = getOrCreateUser(Address.fromString(claim.debtor));
 
@@ -79,6 +97,7 @@ export function handleInvoicePaid(event: InvoicePaid): void {
   invoicePaidEvent.timestamp = event.block.timestamp;
   invoicePaidEvent.save();
 
+  claim.lastPaymentDate = event.block.timestamp;
   claim.lastUpdatedBlockNumber = event.block.number;
   claim.lastUpdatedTimestamp = event.block.timestamp;
   claim.save();
@@ -154,6 +173,11 @@ export function handlePurchaseOrderDelivered(event: PurchaseOrderDelivered): voi
 
   // Update the underlying claim
   const claim = getOrCreateClaim(claimId, "v2");
+
+  const invoiceDetailsEntity = getOrCreateInvoiceDetails(claim.id, event);
+  invoiceDetailsEntity.isDelivered = true;
+  invoiceDetailsEntity.save();
+  claim.invoiceDetails = invoiceDetailsEntity.id;
 
   // Create the PurchaseOrderDeliveredEvent
   const purchaseOrderDeliveredEvent = getPurchaseOrderDeliveredEventId(ev.claimId, event);

--- a/bulla-contracts/src/mappings/BullaManager.ts
+++ b/bulla-contracts/src/mappings/BullaManager.ts
@@ -1,7 +1,8 @@
 import { FeeChanged, CollectorChanged, OwnerChanged, BullaTokenChanged, FeeThresholdChanged, ReducedFeeChanged } from "../../generated/BullaManager/BullaManager";
-import { getOrCreateBullaManager, getOrCreateToken, getOrCreateUser } from "../functions/common";
+import { getOrCreateBullaManager, getOrCreateToken, getOrCreateUser, getOrCreateBullaTransaction } from "../functions/common";
 
 export function handleFeeChanged(event: FeeChanged): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const bullaManager = getOrCreateBullaManager(event);
   bullaManager.feeBasisPoints = ev.newFee.toI32();
@@ -12,6 +13,7 @@ export function handleFeeChanged(event: FeeChanged): void {
 }
 
 export function handleCollectorChanged(event: CollectorChanged): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const bullaManager = getOrCreateBullaManager(event);
   const user = getOrCreateUser(ev.newCollector);
@@ -24,6 +26,7 @@ export function handleCollectorChanged(event: CollectorChanged): void {
 }
 
 export function handleOwnerChanged(event: OwnerChanged): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const bullaManager = getOrCreateBullaManager(event);
 
@@ -35,6 +38,7 @@ export function handleOwnerChanged(event: OwnerChanged): void {
 }
 
 export function handleBullaTokenChanged(event: BullaTokenChanged): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const token = getOrCreateToken(ev.newBullaToken);
   const bullaManager = getOrCreateBullaManager(event);
@@ -47,6 +51,7 @@ export function handleBullaTokenChanged(event: BullaTokenChanged): void {
 }
 
 export function handleFeeThresholdChanged(event: FeeThresholdChanged): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const bullaManager = getOrCreateBullaManager(event);
 
@@ -58,6 +63,7 @@ export function handleFeeThresholdChanged(event: FeeThresholdChanged): void {
 }
 
 export function handleReducedFeeChanged(event: ReducedFeeChanged): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const bullaManager = getOrCreateBullaManager(event);
 

--- a/bulla-contracts/src/mappings/BullaSwap.ts
+++ b/bulla-contracts/src/mappings/BullaSwap.ts
@@ -1,22 +1,31 @@
 import { OrderCreated, OrderDeleted, OrderExecuted } from "../../generated/BullaSwap/BullaSwap";
-import { OrderERC20 } from "../../generated/schema";
-import { createOrderCreatedEvent, createOrderDeletedEvent, createOrderExecutedEvent } from "../functions/BullaSwap";
-import { getOrCreateToken, getOrCreateUser } from "../functions/common";
+import {
+  createOrderCreatedEvent,
+  createOrderDeletedEvent,
+  createOrderExecutedEvent,
+  getOrCreateOrder,
+  SWAP_ORDER_STATUS_CANCELED,
+  SWAP_ORDER_STATUS_EXECUTED,
+  SWAP_ORDER_STATUS_PENDING,
+} from "../functions/BullaSwap";
+import { getOrCreateUser } from "../functions/common";
 
 export function handleOrderCreated(event: OrderCreated): void {
   const ev = event.params;
   const orderId = ev.orderId;
 
-  // Create the order entity
-  const order = new OrderERC20(orderId.toString());
-  order.orderId = orderId;
-  order.expiry = ev.order.expiry;
-  order.signerWallet = ev.order.signerWallet;
-  order.signerToken = getOrCreateToken(ev.order.signerToken).id;
-  order.signerAmount = ev.order.signerAmount;
-  order.senderWallet = ev.order.senderWallet;
-  order.senderToken = getOrCreateToken(ev.order.senderToken).id;
-  order.senderAmount = ev.order.senderAmount;
+  const order = getOrCreateOrder(
+    orderId,
+    ev.order.expiry,
+    ev.order.signerWallet,
+    ev.order.signerToken,
+    ev.order.signerAmount,
+    ev.order.senderWallet,
+    ev.order.senderToken,
+    ev.order.senderAmount,
+    event,
+  );
+  order.status = SWAP_ORDER_STATUS_PENDING;
   order.save();
 
   // Create the event entity
@@ -46,16 +55,20 @@ export function handleOrderExecuted(event: OrderExecuted): void {
   const ev = event.params;
   const orderId = ev.orderId;
 
-  // Create the order entity
-  const order = new OrderERC20(orderId.toString());
-  order.orderId = orderId;
-  order.expiry = ev.order.expiry;
-  order.signerWallet = ev.order.signerWallet;
-  order.signerToken = getOrCreateToken(ev.order.signerToken).id;
-  order.signerAmount = ev.order.signerAmount;
-  order.senderWallet = ev.order.senderWallet;
-  order.senderToken = getOrCreateToken(ev.order.senderToken).id;
-  order.senderAmount = ev.order.senderAmount;
+  const order = getOrCreateOrder(
+    orderId,
+    ev.order.expiry,
+    ev.order.signerWallet,
+    ev.order.signerToken,
+    ev.order.signerAmount,
+    ev.order.senderWallet,
+    ev.order.senderToken,
+    ev.order.senderAmount,
+    event,
+  );
+  order.status = SWAP_ORDER_STATUS_EXECUTED;
+  order.executedAt = event.block.timestamp;
+  order.recipient = ev.recipient;
   order.save();
 
   // Create the event entity
@@ -85,16 +98,19 @@ export function handleOrderDeleted(event: OrderDeleted): void {
   const ev = event.params;
   const orderId = ev.orderId;
 
-  // Create the order entity
-  const order = new OrderERC20(orderId.toString());
-  order.orderId = orderId;
-  order.expiry = ev.order.expiry;
-  order.signerWallet = ev.order.signerWallet;
-  order.signerToken = getOrCreateToken(ev.order.signerToken).id;
-  order.signerAmount = ev.order.signerAmount;
-  order.senderWallet = ev.order.senderWallet;
-  order.senderToken = getOrCreateToken(ev.order.senderToken).id;
-  order.senderAmount = ev.order.senderAmount;
+  const order = getOrCreateOrder(
+    orderId,
+    ev.order.expiry,
+    ev.order.signerWallet,
+    ev.order.signerToken,
+    ev.order.signerAmount,
+    ev.order.senderWallet,
+    ev.order.senderToken,
+    ev.order.senderAmount,
+    event,
+  );
+  order.status = SWAP_ORDER_STATUS_CANCELED;
+  order.canceledAt = event.block.timestamp;
   order.save();
 
   // Create the event entity

--- a/bulla-contracts/src/mappings/BullaSwap.ts
+++ b/bulla-contracts/src/mappings/BullaSwap.ts
@@ -8,9 +8,10 @@ import {
   SWAP_ORDER_STATUS_EXECUTED,
   SWAP_ORDER_STATUS_PENDING,
 } from "../functions/BullaSwap";
-import { getOrCreateUser } from "../functions/common";
+import { getOrCreateUser, getOrCreateBullaTransaction } from "../functions/common";
 
 export function handleOrderCreated(event: OrderCreated): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const orderId = ev.orderId;
 
@@ -52,6 +53,7 @@ export function handleOrderCreated(event: OrderCreated): void {
 }
 
 export function handleOrderExecuted(event: OrderExecuted): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const orderId = ev.orderId;
 
@@ -95,6 +97,7 @@ export function handleOrderExecuted(event: OrderExecuted): void {
 }
 
 export function handleOrderDeleted(event: OrderDeleted): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const orderId = ev.orderId;
 

--- a/bulla-contracts/src/mappings/FrendLend.ts
+++ b/bulla-contracts/src/mappings/FrendLend.ts
@@ -22,8 +22,7 @@ import {
   getOrCreateUser,
   LOAN_OFFER_STATUS_ACCEPTED,
   LOAN_OFFER_STATUS_OFFERED,
-  LOAN_OFFER_STATUS_REJECTED,
-} from "../functions/common";
+  LOAN_OFFER_STATUS_REJECTED, getOrCreateBullaTransaction,} from "../functions/common";
 import {
   createFeeWithdrawnEvent,
   createLoanOfferAcceptedEvent,
@@ -40,10 +39,12 @@ import * as BullaBanker from "./BullaBanker";
 
 // this contract also emits BullaTagUpdatedEvents
 export function handleBullaTagUpdated(event: BullaTagUpdated): void {
+  getOrCreateBullaTransaction(event);
   BullaBanker.handleBullaTagUpdated(event);
 }
 
 export function handleLoanOffered(event: LoanOffered): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const offer = event.params.loanOffer;
 
@@ -96,6 +97,7 @@ export function handleLoanOffered(event: LoanOffered): void {
 }
 
 export function handleLoanOfferedV2(event: LoanOfferedV2): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const offer = event.params.loanOffer;
   const metadata = event.params.metadata;
@@ -156,6 +158,7 @@ export function handleLoanOfferedV2(event: LoanOfferedV2): void {
 }
 
 export function handleLoanOfferAccepted(event: LoanOfferAccepted): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const loanId = event.params.loanId;
 
@@ -217,6 +220,7 @@ export function handleLoanOfferAccepted(event: LoanOfferAccepted): void {
 }
 
 export function handleLoanOfferAcceptedV2(event: LoanOfferAcceptedV2): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const offerId = event.params.offerId;
 
@@ -278,6 +282,7 @@ export function handleLoanOfferAcceptedV2(event: LoanOfferAcceptedV2): void {
 }
 
 export function handleLoanOfferRejected(event: LoanOfferRejected): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const loanId = event.params.loanId;
 
@@ -313,6 +318,7 @@ export function handleLoanOfferRejected(event: LoanOfferRejected): void {
 }
 
 export function handleFeeWithdrawn(event: FeeWithdrawn): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
 
   const feeWithdrawnEvent = createFeeWithdrawnEvent(event);
@@ -335,6 +341,7 @@ export function handleFeeWithdrawn(event: FeeWithdrawn): void {
 }
 
 export function handleLoanPayment(event: LoanPayment): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
 
   const loanPaymentEvent = createLoanPaymentEvent(event);
@@ -402,6 +409,7 @@ export function handleLoanPayment(event: LoanPayment): void {
 }
 
 export function handleLoanOfferRejectedV2(event: LoanOfferRejectedV2): void {
+  getOrCreateBullaTransaction(event);
   const ev = event.params;
   const offerId = event.params.offerId;
 

--- a/bulla-contracts/src/mappings/FrendLend.ts
+++ b/bulla-contracts/src/mappings/FrendLend.ts
@@ -8,8 +8,22 @@ import {
   LoanPayment,
 } from "../../generated/BullaFrendLendV2/BullaFrendLendV2";
 import { LoanOfferAccepted, LoanOffered, LoanOfferRejected } from "../../generated/FrendLend/FrendLend";
-import { getOrCreateClaim } from "../functions/BullaClaimERC721";
-import { BULLA_CLAIM_VERSION_V1, BULLA_CLAIM_VERSION_V2, getIPFSHash_loanOffered, getOrCreateToken, getOrCreateUser } from "../functions/common";
+import { LoanOffer } from "../../generated/schema";
+import { getClaim, getOrCreateClaim } from "../functions/BullaClaimERC721";
+import {
+  BULLA_CLAIM_VERSION_V1,
+  BULLA_CLAIM_VERSION_V2,
+  CLAIM_FINANCING_KIND_ACCEPTED,
+  CLAIM_FINANCING_ORIGINATION_FRENDLEND,
+  getIPFSHash_loanOffered,
+  getOrCreateClaimFinancing,
+  getOrCreateLoanOffer,
+  getOrCreateToken,
+  getOrCreateUser,
+  LOAN_OFFER_STATUS_ACCEPTED,
+  LOAN_OFFER_STATUS_OFFERED,
+  LOAN_OFFER_STATUS_REJECTED,
+} from "../functions/common";
 import {
   createFeeWithdrawnEvent,
   createLoanOfferAcceptedEvent,
@@ -60,6 +74,22 @@ export function handleLoanOffered(event: LoanOffered): void {
   user_creditor.frendLendEvents = user_creditor.frendLendEvents ? user_creditor.frendLendEvents.concat([loanOfferedEvent.id]) : [loanOfferedEvent.id];
   user_debtor.frendLendEvents = user_debtor.frendLendEvents ? user_debtor.frendLendEvents.concat([loanOfferedEvent.id]) : [loanOfferedEvent.id];
 
+  const loanOffer = getOrCreateLoanOffer(ev.loanId.toString(), "v1", event);
+  loanOffer.version = BULLA_CLAIM_VERSION_V1;
+  loanOffer.status = LOAN_OFFER_STATUS_OFFERED;
+  loanOffer.offeredBy = ev.offeredBy;
+  loanOffer.creditor = offer.creditor;
+  loanOffer.debtor = offer.debtor;
+  loanOffer.loanAmount = offer.loanAmount;
+  loanOffer.token = getOrCreateToken(offer.claimToken).id;
+  loanOffer.interestBPS = offer.interestBPS;
+  loanOffer.termLength = offer.termLength;
+  loanOffer.description = offer.description;
+  loanOffer.ipfsHash = getIPFSHash_loanOffered(offer.attachment);
+  loanOffer.offerDate = event.block.timestamp;
+  loanOffer.offerTxHash = event.transaction.hash;
+  loanOffer.save();
+
   loanOfferedEvent.save();
   user_creditor.save();
   user_debtor.save();
@@ -100,6 +130,26 @@ export function handleLoanOfferedV2(event: LoanOfferedV2): void {
   user_creditor.frendLendEvents = user_creditor.frendLendEvents ? user_creditor.frendLendEvents.concat([loanOfferedEvent.id]) : [loanOfferedEvent.id];
   user_debtor.frendLendEvents = user_debtor.frendLendEvents ? user_debtor.frendLendEvents.concat([loanOfferedEvent.id]) : [loanOfferedEvent.id];
 
+  const loanOffer = getOrCreateLoanOffer(ev.offerId.toString(), "v2", event);
+  loanOffer.version = BULLA_CLAIM_VERSION_V2;
+  loanOffer.status = LOAN_OFFER_STATUS_OFFERED;
+  loanOffer.offeredBy = ev.offeredBy;
+  loanOffer.creditor = offer.creditor;
+  loanOffer.debtor = offer.debtor;
+  loanOffer.loanAmount = offer.loanAmount;
+  loanOffer.token = getOrCreateToken(offer.token).id;
+  loanOffer.interestBPS = offer.interestConfig.interestRateBps;
+  loanOffer.numberOfPeriodsPerYear = offer.interestConfig.numberOfPeriodsPerYear;
+  loanOffer.termLength = offer.termLength;
+  loanOffer.description = offer.description;
+  loanOffer.attachmentURI = metadata.attachmentURI;
+  loanOffer.tokenURI = metadata.tokenURI;
+  loanOffer.impairmentGracePeriod = offer.impairmentGracePeriod;
+  loanOffer.expiresAt = offer.expiresAt;
+  loanOffer.offerDate = event.block.timestamp;
+  loanOffer.offerTxHash = event.transaction.hash;
+  loanOffer.save();
+
   loanOfferedEvent.save();
   user_creditor.save();
   user_debtor.save();
@@ -128,6 +178,38 @@ export function handleLoanOfferAccepted(event: LoanOfferAccepted): void {
 
   user_creditor.frendLendEvents = user_creditor.frendLendEvents ? user_creditor.frendLendEvents.concat([loanOfferAcceptedEvent.id]) : [loanOfferAcceptedEvent.id];
   user_debtor.frendLendEvents = user_debtor.frendLendEvents ? user_debtor.frendLendEvents.concat([loanOfferAcceptedEvent.id]) : [loanOfferAcceptedEvent.id];
+
+  // Denormalized financing state on the loan claim created by acceptance.
+  // v1 frendlend creates the claim with a 1-wei sentinel baked into amount and
+  // paidAmount; surface the net values so consumers don't re-walk logs.
+  const claim = getClaim(ev.claimId.toString(), "v1");
+
+  // Flip the denormalized loan-offer lifecycle to Accepted and link the claim.
+  const loanOffer = getOrCreateLoanOffer(loanId.toString(), "v1", event);
+  loanOffer.status = LOAN_OFFER_STATUS_ACCEPTED;
+  loanOffer.claim = claim.id;
+  loanOffer.claimId = claim.id;
+  loanOffer.tokenId = ev.claimId.toString();
+  loanOffer.processingFee = BigInt.fromI32(0); // V1 has no processingFee
+  loanOffer.acceptedDate = event.block.timestamp;
+  loanOffer.acceptedTxHash = event.transaction.hash;
+  loanOffer.save();
+
+  const financing = getOrCreateClaimFinancing(claim.id, event);
+  financing.kind = CLAIM_FINANCING_KIND_ACCEPTED;
+  financing.origination = CLAIM_FINANCING_ORIGINATION_FRENDLEND;
+  financing.interestBps = loanOfferedEvent.interestBPS;
+  financing.termLength = loanOfferedEvent.termLength;
+  financing.loanAmount = loanOfferedEvent.loanAmount;
+  financing.loanOffer = loanOffer.id;
+  // Strip the 1-wei acceptance sentinel, clamping at zero so a not-yet-repaid
+  // loan reads 0 rather than -1.
+  const oneWei = BigInt.fromI32(1);
+  financing.netAmount = claim.amount.ge(oneWei) ? claim.amount.minus(oneWei) : claim.amount;
+  financing.netPaidAmount = claim.paidAmount.ge(oneWei) ? claim.paidAmount.minus(oneWei) : claim.paidAmount;
+  financing.save();
+  claim.financing = financing.id;
+  claim.save();
 
   loanOfferAcceptedEvent.save();
   user_creditor.save();
@@ -162,6 +244,34 @@ export function handleLoanOfferAcceptedV2(event: LoanOfferAcceptedV2): void {
   user_creditor.frendLendEvents = user_creditor.frendLendEvents ? user_creditor.frendLendEvents.concat([loanOfferAcceptedEvent.id]) : [loanOfferAcceptedEvent.id];
   user_debtor.frendLendEvents = user_debtor.frendLendEvents ? user_debtor.frendLendEvents.concat([loanOfferAcceptedEvent.id]) : [loanOfferAcceptedEvent.id];
 
+  // Denormalized financing state on the loan claim created by acceptance.
+  const claim = getOrCreateClaim(ev.claimId.toString(), BULLA_CLAIM_VERSION_V2);
+
+  // Flip the denormalized loan-offer lifecycle to Accepted and link the claim.
+  const loanOffer = getOrCreateLoanOffer(offerId.toString(), "v2", event);
+  loanOffer.status = LOAN_OFFER_STATUS_ACCEPTED;
+  loanOffer.claim = claim.id;
+  loanOffer.claimId = claim.id;
+  loanOffer.tokenId = ev.claimId.toString();
+  loanOffer.receiver = ev.receiver;
+  loanOffer.processingFee = ev.processingFee;
+  loanOffer.acceptedDate = event.block.timestamp;
+  loanOffer.acceptedTxHash = event.transaction.hash;
+  loanOffer.save();
+
+  const financing = getOrCreateClaimFinancing(claim.id, event);
+  financing.kind = CLAIM_FINANCING_KIND_ACCEPTED;
+  financing.origination = CLAIM_FINANCING_ORIGINATION_FRENDLEND;
+  financing.interestBps = loanOfferedEvent.interestBPS;
+  financing.numberOfPeriodsPerYear = loanOfferedEvent.numberOfPeriodsPerYear;
+  financing.termLength = loanOfferedEvent.termLength;
+  financing.loanAmount = loanOfferedEvent.loanAmount;
+  financing.impairmentGracePeriod = loanOfferedEvent.impairmentGracePeriod;
+  financing.loanOffer = loanOffer.id;
+  financing.save();
+  claim.financing = financing.id;
+  claim.save();
+
   loanOfferAcceptedEvent.save();
   user_creditor.save();
   user_debtor.save();
@@ -189,6 +299,13 @@ export function handleLoanOfferRejected(event: LoanOfferRejected): void {
 
   user_creditor.frendLendEvents = user_creditor.frendLendEvents ? user_creditor.frendLendEvents.concat([loanOfferRejectedEvent.id]) : [loanOfferRejectedEvent.id];
   user_debtor.frendLendEvents = user_debtor.frendLendEvents ? user_debtor.frendLendEvents.concat([loanOfferRejectedEvent.id]) : [loanOfferRejectedEvent.id];
+
+  const loanOffer = getOrCreateLoanOffer(loanId.toString(), "v1", event);
+  loanOffer.status = LOAN_OFFER_STATUS_REJECTED;
+  loanOffer.rejectedBy = ev.rejectedBy;
+  loanOffer.rejectedDate = event.block.timestamp;
+  loanOffer.rejectedTxHash = event.transaction.hash;
+  loanOffer.save();
 
   loanOfferRejectedEvent.save();
   user_creditor.save();
@@ -237,6 +354,38 @@ export function handleLoanPayment(event: LoanPayment): void {
 
   loanPaymentEvent.save();
 
+  // Fold the payment into the denormalized financing aggregates. A LoanPayment
+  // is always a frendlend-accepted loan, so set kind/origination defensively in
+  // case the accept predates this mapping (backfill) and no financing exists yet.
+  const financing = getOrCreateClaimFinancing(claim.id, event);
+  financing.kind = CLAIM_FINANCING_KIND_ACCEPTED;
+  financing.origination = CLAIM_FINANCING_ORIGINATION_FRENDLEND;
+  financing.totalGrossInterestPaid = financing.totalGrossInterestPaid.plus(ev.grossInterestPaid);
+  financing.totalPrincipalPaid = financing.totalPrincipalPaid.plus(ev.principalPaid);
+  financing.totalProtocolFee = financing.totalProtocolFee.plus(ev.protocolFee);
+  financing.paymentCount = financing.paymentCount.plus(BigInt.fromI32(1));
+  financing.lastPaymentDate = event.block.timestamp;
+  financing.save();
+  claim.financing = financing.id;
+
+  // Fold the payment into the originating LoanOffer aggregates. The financing
+  // carries the loanOffer link (its id) set at acceptance — null only on
+  // pre-mapping backfilled accepts, in which case there is no offer to update.
+  const loanOfferId = financing.loanOffer;
+  if (loanOfferId !== null) {
+    const loanOffer = LoanOffer.load(loanOfferId);
+    if (loanOffer !== null) {
+      loanOffer.grossInterestPaid = loanOffer.grossInterestPaid.plus(ev.grossInterestPaid);
+      loanOffer.principalPaid = loanOffer.principalPaid.plus(ev.principalPaid);
+      loanOffer.protocolFee = loanOffer.protocolFee.plus(ev.protocolFee);
+      loanOffer.lastPaymentDate = event.block.timestamp;
+      loanOffer.lastUpdatedTimestamp = event.block.timestamp;
+      loanOffer.lastUpdatedBlock = event.block.number;
+      loanOffer.save();
+    }
+  }
+
+  claim.lastPaymentDate = event.block.timestamp;
   claim.lastUpdatedBlockNumber = event.block.number;
   claim.lastUpdatedTimestamp = event.block.timestamp;
   claim.save();
@@ -274,6 +423,13 @@ export function handleLoanOfferRejectedV2(event: LoanOfferRejectedV2): void {
 
   user_creditor.frendLendEvents = user_creditor.frendLendEvents ? user_creditor.frendLendEvents.concat([loanOfferRejectedEvent.id]) : [loanOfferRejectedEvent.id];
   user_debtor.frendLendEvents = user_debtor.frendLendEvents ? user_debtor.frendLendEvents.concat([loanOfferRejectedEvent.id]) : [loanOfferRejectedEvent.id];
+
+  const loanOffer = getOrCreateLoanOffer(offerId.toString(), "v2", event);
+  loanOffer.status = LOAN_OFFER_STATUS_REJECTED;
+  loanOffer.rejectedBy = ev.rejectedBy;
+  loanOffer.rejectedDate = event.block.timestamp;
+  loanOffer.rejectedTxHash = event.transaction.hash;
+  loanOffer.save();
 
   loanOfferRejectedEvent.save();
   user_creditor.save();

--- a/bulla-contracts/tests/BullaClaimERC721.test.ts
+++ b/bulla-contracts/tests/BullaClaimERC721.test.ts
@@ -610,6 +610,47 @@ test("it handles partial ClaimPaymentV2 events", () => {
   afterEach();
 });
 
+test("it denormalizes originalCreditor and lastPaymentDate (v1)", () => {
+  setupContracts();
+
+  const claimCreatedEvent = newClaimCreatedEventV1(1, CLAIM_TYPE_INVOICE);
+  const ev = claimCreatedEvent.params;
+  handleClaimCreatedV1(claimCreatedEvent);
+
+  const expectedClaimId = "1-v1";
+
+  // Objective fields the client uses to derive claimType off-chain.
+  assert.fieldEquals("Claim", expectedClaimId, "creator", ev.origin.toHexString());
+  assert.fieldEquals("Claim", expectedClaimId, "creditor", ev.creditor.toHexString());
+  assert.fieldEquals("Claim", expectedClaimId, "debtor", ev.debtor.toHexString());
+  // originalCreditor is set at creation and is the same as the creditor here.
+  assert.fieldEquals("Claim", expectedClaimId, "originalCreditor", ev.creditor.toHexString());
+  // impairmentGracePeriod defaulted to 0 for parity across chains.
+  assert.fieldEquals("Claim", expectedClaimId, "impairmentGracePeriod", "0");
+  log.info("✅ should set originalCreditor and default impairmentGracePeriod on v1 ClaimCreated", []);
+
+  // Payment records lastPaymentDate.
+  const fullPaymentEvent = newClaimPaymentEvent(claimCreatedEvent);
+  fullPaymentEvent.block.timestamp = claimCreatedEvent.block.timestamp.plus(BigInt.fromI32(20));
+  fullPaymentEvent.block.number = claimCreatedEvent.block.number.plus(BigInt.fromI32(20));
+  handleClaimPayment(fullPaymentEvent);
+  assert.fieldEquals("Claim", expectedClaimId, "lastPaymentDate", fullPaymentEvent.block.timestamp.toString());
+  log.info("✅ should record lastPaymentDate on ClaimPayment", []);
+
+  // Transfer hands the receivable to ADDRESS_3 (the new creditor).
+  const transferEvent = newTransferEvent(claimCreatedEvent, false);
+  transferEvent.block.timestamp = claimCreatedEvent.block.timestamp.plus(BigInt.fromI32(40));
+  transferEvent.block.number = claimCreatedEvent.block.number.plus(BigInt.fromI32(40));
+  handleTransferV1(transferEvent);
+
+  assert.fieldEquals("Claim", expectedClaimId, "creditor", ADDRESS_3.toHexString());
+  // originalCreditor is unchanged by transfer.
+  assert.fieldEquals("Claim", expectedClaimId, "originalCreditor", ev.creditor.toHexString());
+  log.info("✅ should update creditor on transfer and keep originalCreditor", []);
+
+  afterEach();
+});
+
 //exporting for test coverage
 export {
   handleBullaManagerSetEvent,

--- a/bulla-contracts/tests/BullaFinance.test.ts
+++ b/bulla-contracts/tests/BullaFinance.test.ts
@@ -72,6 +72,15 @@ test("it handles FinancingOffered events", () => {
   assert.fieldEquals("FinancingOfferedEvent", financingOfferedEventId, "logIndex", bullaTagUpdatedEvent.logIndex.toString());
   log.info("✅ should create a FinancingOffered event", []);
 
+  // Denormalized ClaimFinancing on the underlying claim ("1-v1")
+  assert.fieldEquals("Claim", claimId.toString() + "-v1", "financing", claimId.toString() + "-v1");
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v1", "kind", "Offered");
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v1", "origination", "VendorFinancing");
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v1", "minDownPaymentBps", minDownPaymentBPS.toString());
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v1", "interestBps", interestChargedBPS.toString());
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v1", "termLength", termLength.toString());
+  log.info("✅ should denormalize a ClaimFinancing offer", []);
+
   /** assert Users */
   assert.fieldEquals("User", ADDRESS_1.toHexString(), "address", ADDRESS_1.toHexString());
   assert.fieldEquals("User", ADDRESS_2.toHexString(), "address", ADDRESS_2.toHexString());
@@ -146,6 +155,13 @@ test("it handles FinancingAccepted events", () => {
     financingAcceptedEvent.block.timestamp.toString(),
   );
   log.info("✅ should update financed claim's blocknumber and last updated timestamp", []);
+
+  // Denormalized ClaimFinancing on the spun-out financed claim ("2-v1")
+  assert.fieldEquals("Claim", financingAcceptedEvent.params.financedClaimId.toString() + "-v1", "financing", financingAcceptedEvent.params.financedClaimId.toString() + "-v1");
+  assert.fieldEquals("ClaimFinancing", financingAcceptedEvent.params.financedClaimId.toString() + "-v1", "kind", "Accepted");
+  assert.fieldEquals("ClaimFinancing", financingAcceptedEvent.params.financedClaimId.toString() + "-v1", "origination", "VendorFinancing");
+  assert.fieldEquals("ClaimFinancing", financingAcceptedEvent.params.financedClaimId.toString() + "-v1", "originatingTokenId", financingAcceptedEvent.params.originatingClaimId.toString());
+  log.info("✅ should denormalize a ClaimFinancing acceptance", []);
 
   // it should create the user entities
   assert.fieldEquals("User", ADDRESS_1.toHexString(), "address", ADDRESS_1.toHexString());

--- a/bulla-contracts/tests/BullaInstantPayment.test.ts
+++ b/bulla-contracts/tests/BullaInstantPayment.test.ts
@@ -33,6 +33,9 @@ test("it handles InstantPayment events", () => {
   assert.fieldEquals("InstantPaymentEvent", instantPaymentId, "logIndex", instantPaymentEvent.logIndex.toString());
   assert.fieldEquals("InstantPaymentEvent", instantPaymentId, "timestamp", instantPaymentEvent.block.timestamp.toString());
 
+  assert.fieldEquals("InstantPayment", instantPaymentId, "createdAt", instantPaymentEvent.block.timestamp.toString());
+  assert.fieldEquals("InstantPayment", instantPaymentId, "transactionHash", instantPaymentEvent.transaction.hash.toHexString());
+
   assert.fieldEquals("InstantPaymentTag", instantPaymentId, "instantPayment", instantPaymentId);
   assert.fieldEquals("InstantPaymentTag", instantPaymentId, "updatedBy", instantPaymentEvent.params.from.toHexString());
   assert.fieldEquals("InstantPaymentTag", instantPaymentId, "tag", instantPaymentEvent.params.tag.toString());

--- a/bulla-contracts/tests/BullaInvoice.test.ts
+++ b/bulla-contracts/tests/BullaInvoice.test.ts
@@ -117,6 +117,21 @@ test("it handles InvoiceCreated events", () => {
 
   log.info("✅ should create PurchaseOrderState when deliveryDate is set", []);
 
+  // Test denormalized InvoiceDetails sub-entity (1:1 with claim).
+  const invoiceDetailsId = claimId.toString() + "-v2";
+  assert.fieldEquals("InvoiceDetails", invoiceDetailsId, "claim", invoiceDetailsId);
+  assert.fieldEquals("InvoiceDetails", invoiceDetailsId, "deliveryDate", deliveryDate.toString());
+  assert.fieldEquals("InvoiceDetails", invoiceDetailsId, "depositAmount", depositAmount.toString());
+  assert.fieldEquals("InvoiceDetails", invoiceDetailsId, "interestRateBps", interestRateBps.toString());
+  assert.fieldEquals("InvoiceDetails", invoiceDetailsId, "numberOfPeriodsPerYear", numberOfPeriodsPerYear.toString());
+  assert.fieldEquals("InvoiceDetails", invoiceDetailsId, "isDelivered", "false");
+  assert.fieldEquals("InvoiceDetails", invoiceDetailsId, "requestedByCreditor", "true");
+  assert.fieldEquals("InvoiceDetails", invoiceDetailsId, "isProtocolFeeExempt", "false");
+  assert.fieldEquals("InvoiceDetails", invoiceDetailsId, "attachmentURI", attachmentURI);
+  assert.fieldEquals("InvoiceDetails", invoiceDetailsId, "tokenURI", tokenURI);
+  assert.fieldEquals("Claim", invoiceDetailsId, "invoiceDetails", invoiceDetailsId);
+  log.info("✅ should create denormalized InvoiceDetails on InvoiceCreated", []);
+
   afterEach();
 });
 
@@ -228,6 +243,7 @@ test("it handles InvoicePaid events", () => {
 
   assert.fieldEquals("Claim", claimId.toString() + "-v2", "lastUpdatedBlockNumber", blockNum.toString());
   assert.fieldEquals("Claim", claimId.toString() + "-v2", "lastUpdatedTimestamp", timestamp.toString());
+  assert.fieldEquals("Claim", claimId.toString() + "-v2", "lastPaymentDate", timestamp.toString());
 
   log.info("✅ should update claim with payment details", []);
 
@@ -438,6 +454,9 @@ test("it handles PurchaseOrderDelivered for existing purchase order", () => {
   // Test PurchaseOrderState updates
   assert.fieldEquals("PurchaseOrderState", claimId.toString() + "-v2", "isDelivered", "true");
   assert.fieldEquals("PurchaseOrderState", claimId.toString() + "-v2", "lastUpdatedAt", "200");
+
+  // Denormalized InvoiceDetails is flipped to delivered too.
+  assert.fieldEquals("InvoiceDetails", claimId.toString() + "-v2", "isDelivered", "true");
 
   // Test PurchaseOrderDeliveredEvent creation
   const purchaseOrderDeliveredEventId = getPurchaseOrderDeliveredEventId(claimId, purchaseOrderDeliveredEvent);

--- a/bulla-contracts/tests/BullaSwap.test.ts
+++ b/bulla-contracts/tests/BullaSwap.test.ts
@@ -154,5 +154,35 @@ test("it transitions an order Pending -> Executed and preserves createdAt", () =
   afterEach();
 });
 
+test("it records a BullaTransaction for the handled tx", () => {
+  const orderId = BigInt.fromI32(11);
+  const expiry = BigInt.fromI32(100);
+  const signerWallet = ADDRESS_1;
+  const signerToken = ADDRESS_2;
+  const signerAmount = BigInt.fromI32(10000);
+  const senderWallet = ADDRESS_3;
+  const senderToken = ADDRESS_4;
+  const senderAmount = BigInt.fromI32(10000);
+
+  setupContracts();
+
+  const timestamp = BigInt.fromI32(150);
+  const orderCreatedEvent = newOrderCreatedEvent(orderId, signerWallet, signerToken, signerAmount, senderWallet, senderToken, senderAmount, expiry);
+  orderCreatedEvent.block.timestamp = timestamp;
+  orderCreatedEvent.block.number = BigInt.fromI32(150);
+
+  handleOrderCreated(orderCreatedEvent);
+
+  // One idempotent BullaTransaction row keyed by txHash; user is the tx sender.
+  const txId = orderCreatedEvent.transaction.hash.toHexString();
+  assert.fieldEquals("BullaTransaction", txId, "txHash", orderCreatedEvent.transaction.hash.toHexString());
+  assert.fieldEquals("BullaTransaction", txId, "user", orderCreatedEvent.transaction.from.toHexString());
+  assert.fieldEquals("BullaTransaction", txId, "timestamp", timestamp.toString());
+
+  log.info("✅ should record a BullaTransaction for the handled tx", []);
+
+  afterEach();
+});
+
 // exporting for test coverage
 export { handleOrderCreated, handleOrderDeleted, handleOrderExecuted };

--- a/bulla-contracts/tests/BullaSwap.test.ts
+++ b/bulla-contracts/tests/BullaSwap.test.ts
@@ -32,6 +32,14 @@ test("it handles OrderCreated event", () => {
   assert.fieldEquals("OrderCreatedEvent", orderCreatedEventId, "sender", senderWallet.toHexString());
   assert.fieldEquals("OrderERC20", orderId.toString(), "orderId", orderId.toString());
 
+  // Lifecycle: Pending with createdAt + latest txHash denormalized on the order
+  assert.fieldEquals("OrderERC20", orderId.toString(), "status", "Pending");
+  assert.fieldEquals("OrderERC20", orderId.toString(), "createdAt", timestamp.toString());
+  assert.fieldEquals("OrderERC20", orderId.toString(), "transactionHash", orderCreatedEvent.transaction.hash.toHexString());
+  assert.fieldEquals("OrderERC20", orderId.toString(), "expiry", expiry.toString());
+  assert.fieldEquals("OrderERC20", orderId.toString(), "signerWallet", signerWallet.toHexString());
+  assert.fieldEquals("OrderERC20", orderId.toString(), "senderWallet", senderWallet.toHexString());
+
   log.info("✅ should create a OrderCreated event", []);
 
   afterEach();
@@ -63,6 +71,12 @@ test("it handles OrderExecuted event", () => {
   assert.fieldEquals("OrderExecutedEvent", orderExecutedEventId, "sender", senderWallet.toHexString());
   assert.fieldEquals("OrderERC20", orderId.toString(), "orderId", orderId.toString());
 
+  // Lifecycle: Executed, with executedAt + recipient (testtool sets recipient = signerWallet)
+  assert.fieldEquals("OrderERC20", orderId.toString(), "status", "Executed");
+  assert.fieldEquals("OrderERC20", orderId.toString(), "executedAt", timestamp.toString());
+  assert.fieldEquals("OrderERC20", orderId.toString(), "recipient", signerWallet.toHexString());
+  assert.fieldEquals("OrderERC20", orderId.toString(), "transactionHash", orderExecutedEvent.transaction.hash.toHexString());
+
   log.info("✅ should create a OrderExecuted event", []);
 
   afterEach();
@@ -93,7 +107,49 @@ test("it handles OrderDeleted event", () => {
   assert.fieldEquals("OrderDeletedEvent", orderDeletedEventId, "signerWallet", signerWallet.toHexString());
   assert.fieldEquals("OrderERC20", orderId.toString(), "orderId", orderId.toString());
 
+  // Lifecycle: Canceled, with canceledAt set
+  assert.fieldEquals("OrderERC20", orderId.toString(), "status", "Canceled");
+  assert.fieldEquals("OrderERC20", orderId.toString(), "canceledAt", timestamp.toString());
+  assert.fieldEquals("OrderERC20", orderId.toString(), "transactionHash", orderDeletedEvent.transaction.hash.toHexString());
+
   log.info("✅ should create a OrderDeleted event", []);
+
+  afterEach();
+});
+
+test("it transitions an order Pending -> Executed and preserves createdAt", () => {
+  const orderId = BigInt.fromI32(7);
+  const expiry = BigInt.fromI32(100);
+  const signerWallet = ADDRESS_1;
+  const signerToken = ADDRESS_2;
+  const signerAmount = BigInt.fromI32(10000);
+  const senderWallet = ADDRESS_3;
+  const senderToken = ADDRESS_4;
+  const senderAmount = BigInt.fromI32(10000);
+
+  setupContracts();
+
+  const createdEvent = newOrderCreatedEvent(orderId, signerWallet, signerToken, signerAmount, senderWallet, senderToken, senderAmount, expiry);
+  createdEvent.block.timestamp = BigInt.fromI32(100);
+  createdEvent.block.number = BigInt.fromI32(100);
+  handleOrderCreated(createdEvent);
+
+  assert.fieldEquals("OrderERC20", orderId.toString(), "status", "Pending");
+  assert.fieldEquals("OrderERC20", orderId.toString(), "createdAt", "100");
+
+  const executedEvent = newOrderExecutedEvent(orderId, signerWallet, signerToken, signerAmount, senderWallet, senderToken, senderAmount, expiry);
+  executedEvent.block.timestamp = BigInt.fromI32(200);
+  executedEvent.block.number = BigInt.fromI32(200);
+  handleOrderExecuted(executedEvent);
+
+  // Same row flips to Executed; createdAt unchanged, executedAt + latest txHash updated
+  assert.fieldEquals("OrderERC20", orderId.toString(), "status", "Executed");
+  assert.fieldEquals("OrderERC20", orderId.toString(), "createdAt", "100");
+  assert.fieldEquals("OrderERC20", orderId.toString(), "executedAt", "200");
+  assert.fieldEquals("OrderERC20", orderId.toString(), "lastUpdatedTimestamp", "200");
+  assert.fieldEquals("OrderERC20", orderId.toString(), "transactionHash", executedEvent.transaction.hash.toHexString());
+
+  log.info("✅ should transition an order through its lifecycle on the same row", []);
 
   afterEach();
 });

--- a/bulla-contracts/tests/FrendLend.test.ts
+++ b/bulla-contracts/tests/FrendLend.test.ts
@@ -78,6 +78,23 @@ test("it handles LoanOffered events", () => {
   assert.fieldEquals("LoanOfferedEvent", loanOfferedEventId, "logIndex", loanOfferedEvent.logIndex.toString());
   log.info("✅ should create a LoanOffered event", []);
 
+  // Denormalized LoanOffer (claim-independent, pending offer)
+  assert.fieldEquals("LoanOffer", "1-v1", "loanId", "1");
+  assert.fieldEquals("LoanOffer", "1-v1", "version", "V1");
+  assert.fieldEquals("LoanOffer", "1-v1", "status", "Offered");
+  assert.fieldEquals("LoanOffer", "1-v1", "offeredBy", creditor.toHexString());
+  assert.fieldEquals("LoanOffer", "1-v1", "creditor", creditor.toHexString());
+  assert.fieldEquals("LoanOffer", "1-v1", "debtor", debtor.toHexString());
+  assert.fieldEquals("LoanOffer", "1-v1", "loanAmount", loanAmount.toString());
+  assert.fieldEquals("LoanOffer", "1-v1", "token", MOCK_WETH_ADDRESS.toHexString());
+  assert.fieldEquals("LoanOffer", "1-v1", "interestBPS", interestBPS.toString());
+  assert.fieldEquals("LoanOffer", "1-v1", "termLength", termLength.toString());
+  assert.fieldEquals("LoanOffer", "1-v1", "description", description);
+  assert.fieldEquals("LoanOffer", "1-v1", "ipfsHash", IPFS_HASH);
+  assert.fieldEquals("LoanOffer", "1-v1", "offerDate", timestamp.toString());
+  assert.fieldEquals("LoanOffer", "1-v1", "offerTxHash", loanOfferedEvent.transaction.hash.toHexString());
+  log.info("✅ should denormalize a pending LoanOffer", []);
+
   afterEach();
 });
 
@@ -127,6 +144,28 @@ test("it handles LoanOfferAccepted events", () => {
   assert.fieldEquals("LoanOfferAcceptedEvent", loanOfferAcceptedEventId, "transactionHash", loanOfferAcceptedEvent.transaction.hash.toHexString());
   assert.fieldEquals("LoanOfferAcceptedEvent", loanOfferAcceptedEventId, "timestamp", loanOfferAcceptedEvent.block.timestamp.toString());
   assert.fieldEquals("LoanOfferAcceptedEvent", loanOfferAcceptedEventId, "logIndex", loanOfferAcceptedEvent.logIndex.toString());
+
+  // Denormalized ClaimFinancing on the accepted v1 loan claim ("1-v1")
+  assert.fieldEquals("Claim", claimId.toString() + "-v1", "financing", claimId.toString() + "-v1");
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v1", "kind", "Accepted");
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v1", "origination", "FrendLend");
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v1", "interestBps", interestBPS.toString());
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v1", "termLength", termLength.toString());
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v1", "loanAmount", loanAmount.toString());
+  // v1 frendlend bakes a 1-wei sentinel into amount/paidAmount; net strips it (claim amount=1e18, paid=0)
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v1", "netAmount", "999999999999999999");
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v1", "netPaidAmount", "0");
+
+  // Denormalized LoanOffer flipped to Accepted, linked to the minted claim
+  assert.fieldEquals("LoanOffer", "1-v1", "status", "Accepted");
+  assert.fieldEquals("LoanOffer", "1-v1", "claim", claimId.toString() + "-v1");
+  assert.fieldEquals("LoanOffer", "1-v1", "claimId", claimId.toString() + "-v1");
+  assert.fieldEquals("LoanOffer", "1-v1", "tokenId", claimId.toString());
+  assert.fieldEquals("LoanOffer", "1-v1", "processingFee", "0");
+  assert.fieldEquals("LoanOffer", "1-v1", "acceptedDate", timestamp.toString());
+  assert.fieldEquals("LoanOffer", "1-v1", "acceptedTxHash", loanOfferAcceptedEvent.transaction.hash.toHexString());
+  // ClaimFinancing carries the reverse link used by handleLoanPayment to fold aggregates
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v1", "loanOffer", "1-v1");
   log.info("✅ should create a LoanOfferAccepted event", []);
 
   afterEach();
@@ -169,6 +208,12 @@ test("it handles LoanOfferRejected events", () => {
   assert.fieldEquals("LoanOfferRejectedEvent", loanOfferRejectedEventId, "transactionHash", loanOfferRejectedEvent.transaction.hash.toHexString());
   assert.fieldEquals("LoanOfferRejectedEvent", loanOfferRejectedEventId, "timestamp", loanOfferRejectedEvent.block.timestamp.toString());
   assert.fieldEquals("LoanOfferRejectedEvent", loanOfferRejectedEventId, "logIndex", loanOfferRejectedEvent.logIndex.toString());
+
+  // Denormalized LoanOffer flipped to Rejected
+  assert.fieldEquals("LoanOffer", "1-v1", "status", "Rejected");
+  assert.fieldEquals("LoanOffer", "1-v1", "rejectedBy", ADDRESS_3.toHexString());
+  assert.fieldEquals("LoanOffer", "1-v1", "rejectedDate", loanOfferRejectedEvent.block.timestamp.toString());
+  assert.fieldEquals("LoanOffer", "1-v1", "rejectedTxHash", loanOfferRejectedEvent.transaction.hash.toHexString());
   log.info("✅ should create a LoanOfferRejected event", []);
 
   afterEach();
@@ -233,6 +278,26 @@ test("it handles FrendLendV2 events", () => {
   assert.fieldEquals("LoanOfferedEvent", loanOfferedEventId, "timestamp", loanOfferedEventV2.block.timestamp.toString());
   assert.fieldEquals("LoanOfferedEvent", loanOfferedEventId, "logIndex", loanOfferedEventV2.logIndex.toString());
 
+  // Denormalized LoanOffer in the Offered state (v2)
+  assert.fieldEquals("LoanOffer", "2-v2", "loanId", offerId.toString());
+  assert.fieldEquals("LoanOffer", "2-v2", "version", "V2");
+  assert.fieldEquals("LoanOffer", "2-v2", "status", "Offered");
+  assert.fieldEquals("LoanOffer", "2-v2", "offeredBy", loanOfferedEventV2.params.offeredBy.toHexString());
+  assert.fieldEquals("LoanOffer", "2-v2", "creditor", creditor.toHexString());
+  assert.fieldEquals("LoanOffer", "2-v2", "debtor", debtor.toHexString());
+  assert.fieldEquals("LoanOffer", "2-v2", "loanAmount", loanAmount.toString());
+  assert.fieldEquals("LoanOffer", "2-v2", "token", token.toHexString());
+  assert.fieldEquals("LoanOffer", "2-v2", "interestBPS", interestRateBps.toString());
+  assert.fieldEquals("LoanOffer", "2-v2", "numberOfPeriodsPerYear", "12");
+  assert.fieldEquals("LoanOffer", "2-v2", "termLength", termLength.toString());
+  assert.fieldEquals("LoanOffer", "2-v2", "expiresAt", expiresAt.toString());
+  assert.fieldEquals("LoanOffer", "2-v2", "description", description);
+  assert.fieldEquals("LoanOffer", "2-v2", "attachmentURI", loanOfferedEventV2.params.metadata.attachmentURI);
+  assert.fieldEquals("LoanOffer", "2-v2", "tokenURI", loanOfferedEventV2.params.metadata.tokenURI);
+  assert.fieldEquals("LoanOffer", "2-v2", "impairmentGracePeriod", impairmentGracePeriod.toString());
+  assert.fieldEquals("LoanOffer", "2-v2", "offerDate", timestamp.toString());
+  assert.fieldEquals("LoanOffer", "2-v2", "offerTxHash", loanOfferedEventV2.transaction.hash.toHexString());
+
   // loan acceptance flow
   const claimId = BigInt.fromI32(2);
   const fee = BigInt.fromI32(50000); // 0.05 ETH fee
@@ -242,15 +307,12 @@ test("it handles FrendLendV2 events", () => {
   loanOfferAcceptedEventV2.block.timestamp = timestamp;
   loanOfferAcceptedEventV2.block.number = blockNum;
 
-  const claimCreatedEvent = newClaimCreatedEventV1(claimId.toU32(), CLAIM_TYPE_INVOICE);
+  // The v2 loan claim is created on-chain by BullaClaimV2 before acceptance.
+  const claimCreatedEvent = newClaimCreatedEventV2(claimId.toU32(), CLAIM_TYPE_INVOICE);
   claimCreatedEvent.block.timestamp = timestamp;
   claimCreatedEvent.block.number = blockNum;
-  const bullaTagUpdatedEvent = newBullaTagUpdatedEvent(claimId, ADDRESS_1, DEFAULT_ACCOUNT_TAG);
-  bullaTagUpdatedEvent.block.timestamp = timestamp;
-  bullaTagUpdatedEvent.block.number = blockNum;
 
-  handleClaimCreatedV1(claimCreatedEvent);
-  handleBullaTagUpdated(bullaTagUpdatedEvent);
+  handleClaimCreatedV2(claimCreatedEvent);
   handleLoanOfferAcceptedV2(loanOfferAcceptedEventV2);
 
   const loanOfferAcceptedEventId = getLoanOfferAcceptedEventId(offerId, claimId, loanOfferAcceptedEventV2);
@@ -269,6 +331,27 @@ test("it handles FrendLendV2 events", () => {
   assert.fieldEquals("LoanOfferAcceptedEvent", loanOfferAcceptedEventId, "transactionHash", loanOfferAcceptedEventV2.transaction.hash.toHexString());
   assert.fieldEquals("LoanOfferAcceptedEvent", loanOfferAcceptedEventId, "timestamp", loanOfferAcceptedEventV2.block.timestamp.toString());
   assert.fieldEquals("LoanOfferAcceptedEvent", loanOfferAcceptedEventId, "logIndex", loanOfferAcceptedEventV2.logIndex.toString());
+
+  // Denormalized ClaimFinancing on the accepted v2 loan claim ("2-v2")
+  assert.fieldEquals("Claim", claimId.toString() + "-v2", "financing", claimId.toString() + "-v2");
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "kind", "Accepted");
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "origination", "FrendLend");
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "interestBps", interestRateBps.toString());
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "numberOfPeriodsPerYear", "12");
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "termLength", termLength.toString());
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "loanAmount", loanAmount.toString());
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "impairmentGracePeriod", impairmentGracePeriod.toString());
+
+  // Denormalized LoanOffer flipped to Accepted, linked to the minted v2 claim
+  assert.fieldEquals("LoanOffer", "2-v2", "status", "Accepted");
+  assert.fieldEquals("LoanOffer", "2-v2", "claim", claimId.toString() + "-v2");
+  assert.fieldEquals("LoanOffer", "2-v2", "claimId", claimId.toString() + "-v2");
+  assert.fieldEquals("LoanOffer", "2-v2", "tokenId", claimId.toString());
+  assert.fieldEquals("LoanOffer", "2-v2", "receiver", debtor.toHexString());
+  assert.fieldEquals("LoanOffer", "2-v2", "processingFee", processingFee.toString());
+  assert.fieldEquals("LoanOffer", "2-v2", "acceptedDate", timestamp.toString());
+  assert.fieldEquals("LoanOffer", "2-v2", "acceptedTxHash", loanOfferAcceptedEventV2.transaction.hash.toHexString());
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "loanOffer", "2-v2");
 
   // loan rejection flow
   const rejectionOfferId = BigInt.fromI32(3);
@@ -315,6 +398,12 @@ test("it handles FrendLendV2 events", () => {
   assert.fieldEquals("LoanOfferRejectedEvent", loanOfferRejectedEventId, "timestamp", loanOfferRejectedEventV2.block.timestamp.toString());
   assert.fieldEquals("LoanOfferRejectedEvent", loanOfferRejectedEventId, "logIndex", loanOfferRejectedEventV2.logIndex.toString());
 
+  // Denormalized LoanOffer flipped to Rejected (v2)
+  assert.fieldEquals("LoanOffer", "3-v2", "status", "Rejected");
+  assert.fieldEquals("LoanOffer", "3-v2", "rejectedBy", ADDRESS_3.toHexString());
+  assert.fieldEquals("LoanOffer", "3-v2", "rejectedDate", loanOfferRejectedEventV2.block.timestamp.toString());
+  assert.fieldEquals("LoanOffer", "3-v2", "rejectedTxHash", loanOfferRejectedEventV2.transaction.hash.toHexString());
+
   log.info("✅ should create all FrendLendV2 events", []);
 
   afterEach();
@@ -332,6 +421,35 @@ test("it handles LoanPayment events", () => {
   claimCreatedEvent.block.number = blockNum;
 
   handleClaimCreatedV2(claimCreatedEvent);
+
+  // Wire a v2 LoanOffer accepted onto claim 5 so handleLoanPayment can fold aggregates
+  const offerId = BigInt.fromI32(5);
+  const offerInterestRateBps = BigInt.fromI32(1000);
+  const offerTermLength = BigInt.fromI32(60 * 24 * 60 * 60);
+  const offerImpairmentGracePeriod = BigInt.fromI32(7 * 24 * 60 * 60);
+  const offerExpiresAt = BigInt.fromI32(1000000000);
+  const offerProcessingFee = BigInt.fromI32(10000);
+
+  const offeredEvent = newLoanOfferedEventV2(
+    offerId,
+    offerInterestRateBps,
+    offerTermLength,
+    BigInt.fromString(ONE_ETH),
+    ADDRESS_1,
+    ADDRESS_2,
+    "LoanPayment fold offer",
+    MOCK_WETH_ADDRESS,
+    offerImpairmentGracePeriod,
+    offerExpiresAt,
+  );
+  offeredEvent.block.timestamp = timestamp;
+  offeredEvent.block.number = blockNum;
+  handleLoanOfferedV2(offeredEvent);
+
+  const acceptedEvent = newLoanOfferAcceptedEventV2(offerId, claimId, ADDRESS_2, BigInt.fromI32(50000), offerProcessingFee);
+  acceptedEvent.block.timestamp = timestamp;
+  acceptedEvent.block.number = blockNum;
+  handleLoanOfferAcceptedV2(acceptedEvent);
 
   // Create the loan payment event
   const grossInterestPaid = BigInt.fromString("50000000000000000"); // 0.05 ETH
@@ -361,6 +479,21 @@ test("it handles LoanPayment events", () => {
   assert.fieldEquals("Claim", claimId.toString() + "-v2", "lastUpdatedBlockNumber", loanPaymentEvent.block.number.toString());
   assert.fieldEquals("Claim", claimId.toString() + "-v2", "lastUpdatedTimestamp", loanPaymentEvent.block.timestamp.toString());
 
+  // Folded ClaimFinancing aggregates after the first payment
+  assert.fieldEquals("Claim", claimId.toString() + "-v2", "financing", claimId.toString() + "-v2");
+  assert.fieldEquals("Claim", claimId.toString() + "-v2", "lastPaymentDate", loanPaymentEvent.block.timestamp.toString());
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "totalGrossInterestPaid", grossInterestPaid.toString());
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "totalPrincipalPaid", principalPaid.toString());
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "totalProtocolFee", protocolFee.toString());
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "paymentCount", "1");
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "lastPaymentDate", loanPaymentEvent.block.timestamp.toString());
+
+  // Folded LoanOffer aggregates after the first payment
+  assert.fieldEquals("LoanOffer", "5-v2", "grossInterestPaid", grossInterestPaid.toString());
+  assert.fieldEquals("LoanOffer", "5-v2", "principalPaid", principalPaid.toString());
+  assert.fieldEquals("LoanOffer", "5-v2", "protocolFee", protocolFee.toString());
+  assert.fieldEquals("LoanOffer", "5-v2", "lastPaymentDate", loanPaymentEvent.block.timestamp.toString());
+
   // Test that creditor and debtor users have the event in their frendLendEvents arrays
   // For CLAIM_TYPE_INVOICE: creditor = ADDRESS_1, debtor = ADDRESS_2
   const creditorUserEntity = User.load(ADDRESS_1.toHexString());
@@ -387,6 +520,20 @@ test("it handles LoanPayment events", () => {
   // After full payment, claim should be marked as PAID
   assert.fieldEquals("Claim", claimId.toString() + "-v2", "lastUpdatedBlockNumber", fullPaymentEvent.block.number.toString());
   assert.fieldEquals("Claim", claimId.toString() + "-v2", "lastUpdatedTimestamp", fullPaymentEvent.block.timestamp.toString());
+
+  // ClaimFinancing aggregates accumulate across both payments
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "totalGrossInterestPaid", grossInterestPaid.plus(additionalInterest).toString());
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "totalPrincipalPaid", principalPaid.plus(fullPrincipalPayment).toString());
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "totalProtocolFee", protocolFee.plus(additionalProtocolFee).toString());
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "paymentCount", "2");
+  assert.fieldEquals("ClaimFinancing", claimId.toString() + "-v2", "lastPaymentDate", fullPaymentEvent.block.timestamp.toString());
+  assert.fieldEquals("Claim", claimId.toString() + "-v2", "lastPaymentDate", fullPaymentEvent.block.timestamp.toString());
+
+  // LoanOffer aggregates accumulate across both payments
+  assert.fieldEquals("LoanOffer", "5-v2", "grossInterestPaid", grossInterestPaid.plus(additionalInterest).toString());
+  assert.fieldEquals("LoanOffer", "5-v2", "principalPaid", principalPaid.plus(fullPrincipalPayment).toString());
+  assert.fieldEquals("LoanOffer", "5-v2", "protocolFee", protocolFee.plus(additionalProtocolFee).toString());
+  assert.fieldEquals("LoanOffer", "5-v2", "lastPaymentDate", fullPaymentEvent.block.timestamp.toString());
 
   // Test that both users also have the second loan payment event
   const fullPaymentEventId = getLoanPaymentEventId(claimId, fullPaymentEvent);


### PR DESCRIPTION
## Summary
- Denormalize claim/financing state (originalCreditor, ClaimFinancing, InvoiceDetails, LoanOffer lifecycle)
- Denormalize InstantPayment timestamps + swap OrderERC20 lifecycle (Pending/Executed/Canceled)
- Add BullaTransaction: one row per Bulla tx (txHash, user, timestamp) — a faithful image of the client's bullaTxHashBitmap