### PR TITLE
fix: BullaTransaction so the per-user tx set matches the client's bullaTxHashBitmap

### DIFF
--- a/bulla-contracts/schema.graphql
+++ b/bulla-contracts/schema.graphql
@@ -941,7 +941,7 @@ type User @entity {
 }
 
 type BullaTransaction @entity {
-  id: ID! # transactionHash (hex)
+  id: ID! # `${user}-${txHash}` (both lowercased hex)
   txHash: Bytes!
   user: User!
   timestamp: BigInt!

--- a/bulla-contracts/src/functions/common.ts
+++ b/bulla-contracts/src/functions/common.ts
@@ -9,6 +9,7 @@ import { LoanOfferedLoanOfferAttachmentStruct } from "../../generated/FrendLend/
 import {
   BullaManager,
   BullaTransaction,
+  Claim,
   ClaimFinancing,
   FactoringPool,
   FactoringPoolStats,
@@ -121,18 +122,31 @@ export const getOrCreateUser = (address: Address): User => {
   return user;
 };
 
-export const getOrCreateBullaTransaction = (event: ethereum.Event): BullaTransaction => {
-  const id = event.transaction.hash.toHexString();
+export const getOrCreateBullaTransaction = (user: Address, event: ethereum.Event): BullaTransaction => {
+  const id = user.toHexString() + "-" + event.transaction.hash.toHexString();
   let bullaTransaction = BullaTransaction.load(id);
   if (!bullaTransaction) {
     bullaTransaction = new BullaTransaction(id);
     bullaTransaction.txHash = event.transaction.hash;
-    bullaTransaction.user = getOrCreateUser(event.transaction.from).id;
+    bullaTransaction.user = getOrCreateUser(user).id;
     bullaTransaction.timestamp = event.block.timestamp;
     bullaTransaction.save();
   }
 
   return bullaTransaction;
+};
+
+// Stamp a BullaTransaction for every party a claim is attached to via User.claims
+// (creditor, debtor, creator, controller) — the same set written at claim creation.
+// Used by claim sub-event handlers that only carry a tokenId, so the bitmap covers
+// value the user received as a party, not just txs they sent.
+export const stampClaimParties = (claim: Claim, event: ethereum.Event): void => {
+  getOrCreateBullaTransaction(Address.fromString(claim.creditor), event);
+  getOrCreateBullaTransaction(Address.fromString(claim.debtor), event);
+  getOrCreateBullaTransaction(Address.fromString(claim.creator), event);
+  if (claim.controller != ADDRESS_ZERO) {
+    getOrCreateBullaTransaction(Address.fromString(claim.controller), event);
+  }
 };
 
 // Mirrors the client's getPayables/getReceivables open-status filter:

--- a/bulla-contracts/src/mappings/BullaBanker.ts
+++ b/bulla-contracts/src/mappings/BullaBanker.ts
@@ -11,7 +11,7 @@ import { isClaimIncompleteV1, tryGetClaim } from "../functions/BullaClaimERC721"
 import { BULLA_CLAIM_VERSION_V1, getOrCreateBullaTransaction } from "../functions/common";
 
 export function handleBullaTagUpdated(event: BullaTagUpdated): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const tag = ev.tag.toString();
   const tokenId = ev.tokenId.toString();
@@ -69,7 +69,7 @@ export function handleBullaTagUpdated(event: BullaTagUpdated): void {
 }
 
 export function handleBullaBankerCreated(event: BullaBankerCreated): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const bullaBankerCreatedEvent = createBullaBankerCreatedEvent(event);
 

--- a/bulla-contracts/src/mappings/BullaBankerModule.ts
+++ b/bulla-contracts/src/mappings/BullaBankerModule.ts
@@ -4,7 +4,7 @@ import { getGnosisModuleConfigId } from "../functions/BullaBankerModule";
 import { getOrCreateUser, getOrCreateBullaTransaction } from "../functions/common";
 
 export function handleBullaBankerModuleDeploy(event: BullaBankerModuleDeploy): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const safeUser = getOrCreateUser(ev.safe);
 

--- a/bulla-contracts/src/mappings/BullaClaimERC721.ts
+++ b/bulla-contracts/src/mappings/BullaClaimERC721.ts
@@ -90,7 +90,6 @@ function logV1ClaimSkip(handler: string, tokenId: string, reason: string, event:
 export function handleTransferV1(event: ERC721TransferEvent): void {
   getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
-  getOrCreateBullaTransaction(ev.to, event); // new owner — transfer tx only, no replay
   const transferId = getTransferEventId(event.params.tokenId, event);
   const tokenId = ev.tokenId.toString();
   const isMintEvent = ev.from.equals(Bytes.fromHexString(ADDRESS_ZERO));
@@ -135,13 +134,15 @@ export function handleTransferV1(event: ERC721TransferEvent): void {
 
     user_newOwner.claims = user_newOwner.claims ? user_newOwner.claims.concat([claim.id]) : [claim.id];
     user_newOwner.save();
+
+    // Stamp the full member set (creditor is now the new owner) — transfer tx only, no replay.
+    stampClaimParties(claim, event);
   }
 }
 
 export function handleTransferV2(event: ERC721TransferEvent): void {
   getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
-  getOrCreateBullaTransaction(ev.to, event); // new owner — transfer tx only, no replay
   const transferId = getTransferEventId(event.params.tokenId, event);
   const tokenId = ev.tokenId.toString();
   const isMintEvent = ev.from.equals(Bytes.fromHexString(ADDRESS_ZERO));
@@ -177,6 +178,9 @@ export function handleTransferV2(event: ERC721TransferEvent): void {
 
     user_newOwner.claims = user_newOwner.claims ? user_newOwner.claims.concat([claim.id]) : [claim.id];
     user_newOwner.save();
+
+    // Stamp the full member set (creditor is now the new owner) — transfer tx only, no replay.
+    stampClaimParties(claim, event);
   }
 }
 
@@ -444,9 +448,7 @@ export function handleClaimCreatedV1(event: ClaimCreatedV1): void {
   user_debtor.save();
   user_creator.save();
 
-  getOrCreateBullaTransaction(ev.creditor, event);
-  getOrCreateBullaTransaction(ev.debtor, event);
-  getOrCreateBullaTransaction(ev.origin, event);
+  stampClaimParties(claim, event);
 
   applyClaimStatusTransition(claim.creditor, claim.debtor, false, isOpenClaimStatus(claim.status), event);
 }
@@ -534,10 +536,7 @@ export function handleClaimCreatedV2(event: ClaimCreatedV2): void {
   user_creator.save();
   user_controller.save();
 
-  getOrCreateBullaTransaction(ev.creditor, event);
-  getOrCreateBullaTransaction(ev.debtor, event);
-  getOrCreateBullaTransaction(ev.from, event);
-  getOrCreateBullaTransaction(ev.controller, event);
+  stampClaimParties(claim, event);
 
   applyClaimStatusTransition(claim.creditor, claim.debtor, false, isOpenClaimStatus(claim.status), event);
 }

--- a/bulla-contracts/src/mappings/BullaClaimERC721.ts
+++ b/bulla-contracts/src/mappings/BullaClaimERC721.ts
@@ -59,7 +59,7 @@ import {
   getIPFSHash_claimCreated,
   getOrCreateToken,
   getOrCreateUser,
-  isOpenClaimStatus, getOrCreateBullaTransaction,} from "../functions/common";
+  isOpenClaimStatus, getOrCreateBullaTransaction, stampClaimParties,} from "../functions/common";
 
 function logEventOrder(eventName: string, version: string, tokenId: string, event: ethereum.Event): void {
   const claimId = tokenId + "-" + version;
@@ -88,8 +88,9 @@ function logV1ClaimSkip(handler: string, tokenId: string, reason: string, event:
 }
 
 export function handleTransferV1(event: ERC721TransferEvent): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
+  getOrCreateBullaTransaction(ev.to, event); // new owner — transfer tx only, no replay
   const transferId = getTransferEventId(event.params.tokenId, event);
   const tokenId = ev.tokenId.toString();
   const isMintEvent = ev.from.equals(Bytes.fromHexString(ADDRESS_ZERO));
@@ -138,8 +139,9 @@ export function handleTransferV1(event: ERC721TransferEvent): void {
 }
 
 export function handleTransferV2(event: ERC721TransferEvent): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
+  getOrCreateBullaTransaction(ev.to, event); // new owner — transfer tx only, no replay
   const transferId = getTransferEventId(event.params.tokenId, event);
   const tokenId = ev.tokenId.toString();
   const isMintEvent = ev.from.equals(Bytes.fromHexString(ADDRESS_ZERO));
@@ -179,10 +181,12 @@ export function handleTransferV2(event: ERC721TransferEvent): void {
 }
 
 export function handleFeePaid(event: FeePaid): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const feePaidEventId = getFeePaidEventId(event.params.tokenId, event);
   const tokenId = ev.tokenId.toString();
+  const claimForParties = tryGetClaim(tokenId, BULLA_CLAIM_VERSION_V1);
+  if (claimForParties !== null) stampClaimParties(claimForParties, event);
   const feePaidEvent = new FeePaidEvent(feePaidEventId);
 
   feePaidEvent.id = feePaidEventId;
@@ -200,7 +204,7 @@ export function handleFeePaid(event: FeePaid): void {
 }
 
 export function handleClaimRescinded(event: ClaimRescinded): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const tokenId = ev.tokenId.toString();
   logEventOrder("ClaimRescinded", "v1", tokenId, event);
@@ -214,6 +218,7 @@ export function handleClaimRescinded(event: ClaimRescinded): void {
     logV1ClaimSkip("handleClaimRescinded", tokenId, "claim_incomplete", event);
     return;
   }
+  stampClaimParties(claim, event);
 
   const claimRescindedEvent = getOrCreateClaimRescindedEvent(claimRescindedEventId);
   claimRescindedEvent.bullaManager = ev.bullaManager;
@@ -236,7 +241,7 @@ export function handleClaimRescinded(event: ClaimRescinded): void {
 }
 
 export function handleClaimRejected(event: ClaimRejected): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const tokenId = ev.tokenId.toString();
   logEventOrder("ClaimRejected", "v1", tokenId, event);
@@ -250,6 +255,7 @@ export function handleClaimRejected(event: ClaimRejected): void {
     logV1ClaimSkip("handleClaimRejected", tokenId, "claim_incomplete", event);
     return;
   }
+  stampClaimParties(claim, event);
 
   const claimRejectedEvent = getOrCreateClaimRejectedEvent(claimRejectedEventId);
   claimRejectedEvent.managerAddress = ev.bullaManager;
@@ -272,7 +278,7 @@ export function handleClaimRejected(event: ClaimRejected): void {
 }
 
 export function handleClaimPayment(event: ClaimPaymentV1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const tokenId = ev.tokenId.toString();
   logEventOrder("ClaimPayment", "v1", tokenId, event);
@@ -285,6 +291,7 @@ export function handleClaimPayment(event: ClaimPaymentV1): void {
     logV1ClaimSkip("handleClaimPayment", tokenId, "claim_incomplete", event);
     return;
   }
+  stampClaimParties(claim, event);
 
   const claimPaymentEventId = getClaimPaymentEventId(event.params.tokenId, event);
   const claimPaymentEvent = getOrCreateClaimPaymentEvent(claimPaymentEventId);
@@ -316,12 +323,13 @@ export function handleClaimPayment(event: ClaimPaymentV1): void {
 }
 
 export function handleClaimPaymentV2(event: ClaimPaymentV2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   logEventOrder("ClaimPayment", "v2", ev.claimId.toString(), event);
   const claimPaymentEventId = getClaimPaymentEventId(event.params.claimId, event);
   const claimPaymentEvent = getOrCreateClaimPaymentEvent(claimPaymentEventId);
   const claim = getOrCreateClaim(ev.claimId.toString(), BULLA_CLAIM_VERSION_V2);
+  stampClaimParties(claim, event);
 
   claimPaymentEvent.bullaManager = Bytes.fromHexString(ADDRESS_ZERO); // Not available in V2
   claimPaymentEvent.claim = claim.id;
@@ -350,7 +358,7 @@ export function handleClaimPaymentV2(event: ClaimPaymentV2): void {
 }
 
 export function handleBullaManagerSetEvent(event: BullaManagerSet): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const bullaManagerSetEvent = createBullaManagerSet(event);
   bullaManagerSetEvent.prevBullaManager = ev.prevBullaManager;
@@ -365,7 +373,7 @@ export function handleBullaManagerSetEvent(event: BullaManagerSet): void {
 }
 
 export function handleClaimCreatedV1(event: ClaimCreatedV1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   logEventOrder("ClaimCreated", "v1", ev.tokenId.toString(), event);
   const token = getOrCreateToken(ev.claim.claimToken);
@@ -436,11 +444,15 @@ export function handleClaimCreatedV1(event: ClaimCreatedV1): void {
   user_debtor.save();
   user_creator.save();
 
+  getOrCreateBullaTransaction(ev.creditor, event);
+  getOrCreateBullaTransaction(ev.debtor, event);
+  getOrCreateBullaTransaction(ev.origin, event);
+
   applyClaimStatusTransition(claim.creditor, claim.debtor, false, isOpenClaimStatus(claim.status), event);
 }
 
 export function handleClaimCreatedV2(event: ClaimCreatedV2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   logEventOrder("ClaimCreated", "v2", ev.claimId.toString(), event);
   const token = getOrCreateToken(ev.token);
@@ -522,14 +534,20 @@ export function handleClaimCreatedV2(event: ClaimCreatedV2): void {
   user_creator.save();
   user_controller.save();
 
+  getOrCreateBullaTransaction(ev.creditor, event);
+  getOrCreateBullaTransaction(ev.debtor, event);
+  getOrCreateBullaTransaction(ev.from, event);
+  getOrCreateBullaTransaction(ev.controller, event);
+
   applyClaimStatusTransition(claim.creditor, claim.debtor, false, isOpenClaimStatus(claim.status), event);
 }
 
 export function handleMetadataAdded(event: MetadataAdded): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const tokenId = ev.claimId.toString();
   const claim = getOrCreateClaim(tokenId, BULLA_CLAIM_VERSION_V2);
+  stampClaimParties(claim, event);
   const metadataAddedEventId = getMetadataAddedEventId(ev.claimId, event);
 
   const metadataAddedEvent = new MetadataAddedEvent(metadataAddedEventId);
@@ -551,12 +569,13 @@ export function handleMetadataAdded(event: MetadataAdded): void {
 }
 
 export function handleBindingUpdated(event: BindingUpdated): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const tokenId = ev.claimId.toString();
   logEventOrder("BindingUpdated", "v2", tokenId, event);
   const bindingUpdatedEventId = getBindingUpdatedEventId(ev.claimId, event);
   const claim = getOrCreateClaim(tokenId, BULLA_CLAIM_VERSION_V2);
+  stampClaimParties(claim, event);
 
   const bindingUpdatedEvent = new BindingUpdatedEvent(bindingUpdatedEventId);
   bindingUpdatedEvent.claim = claim.id;
@@ -576,12 +595,13 @@ export function handleBindingUpdated(event: BindingUpdated): void {
 }
 
 export function handleClaimRejectedV2(event: ClaimRejectedV2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const tokenId = ev.claimId.toString();
   logEventOrder("ClaimRejected", "v2", tokenId, event);
   const claimRejectedEventId = getClaimRejectedEventId(ev.claimId, event);
   const claim = getOrCreateClaim(tokenId, BULLA_CLAIM_VERSION_V2);
+  stampClaimParties(claim, event);
 
   const claimRejectedEvent = getOrCreateClaimRejectedEvent(claimRejectedEventId);
   claimRejectedEvent.managerAddress = Bytes.fromHexString(ADDRESS_ZERO); // No bullaManager in V2
@@ -604,12 +624,13 @@ export function handleClaimRejectedV2(event: ClaimRejectedV2): void {
 }
 
 export function handleClaimRescindedV2(event: ClaimRescindedV2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const tokenId = ev.claimId.toString();
   logEventOrder("ClaimRescinded", "v2", tokenId, event);
   const claimRescindedEventId = getClaimRescindedEventId(ev.claimId, event);
   const claim = getOrCreateClaim(tokenId, BULLA_CLAIM_VERSION_V2);
+  stampClaimParties(claim, event);
 
   const claimRescindedEvent = getOrCreateClaimRescindedEvent(claimRescindedEventId);
   claimRescindedEvent.bullaManager = Bytes.fromHexString(ADDRESS_ZERO); // No bullaManager in V2
@@ -632,12 +653,13 @@ export function handleClaimRescindedV2(event: ClaimRescindedV2): void {
 }
 
 export function handleClaimImpaired(event: ClaimImpaired): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const tokenId = ev.claimId.toString();
   logEventOrder("ClaimImpaired", "v2", tokenId, event);
   const claimImpairedEventId = getClaimImpairedEventId(ev.claimId, event);
   const claim = getOrCreateClaim(tokenId, BULLA_CLAIM_VERSION_V2);
+  stampClaimParties(claim, event);
 
   const claimImpairedEvent = new ClaimImpairedEvent(claimImpairedEventId);
   claimImpairedEvent.claim = claim.id;
@@ -657,12 +679,13 @@ export function handleClaimImpaired(event: ClaimImpaired): void {
 }
 
 export function handleClaimMarkedAsPaid(event: ClaimMarkedAsPaid): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const tokenId = ev.claimId.toString();
   logEventOrder("ClaimMarkedAsPaid", "v2", tokenId, event);
   const claimMarkedAsPaidEventId = getClaimMarkedAsPaidEventId(ev.claimId, event);
   const claim = getOrCreateClaim(tokenId, BULLA_CLAIM_VERSION_V2);
+  stampClaimParties(claim, event);
 
   const claimMarkedAsPaidEvent = new ClaimMarkedAsPaidEvent(claimMarkedAsPaidEventId);
   claimMarkedAsPaidEvent.claim = claim.id;

--- a/bulla-contracts/src/mappings/BullaFactoring.ts
+++ b/bulla-contracts/src/mappings/BullaFactoring.ts
@@ -108,6 +108,9 @@ function handleInvoiceFunded(event: InvoiceFundedV1, version: string): void {
   const underlyingClaim = getClaim(originatingClaimId.toString(), version);
   const InvoiceFundedEvent = createInvoiceFundedEventV1(originatingClaimId, event);
   const debtor = getOrCreateUser(Address.fromString(underlyingClaim.debtor));
+  getOrCreateBullaTransaction(ev.originalCreditor, event);
+  getOrCreateBullaTransaction(Address.fromString(underlyingClaim.debtor), event);
+  getOrCreateBullaTransaction(event.address, event);
 
   const upfrontBps = getApprovedInvoiceUpfrontBps(event.address, version, originatingClaimId);
 
@@ -182,12 +185,12 @@ function handleInvoiceFunded(event: InvoiceFundedV1, version: string): void {
 }
 
 export function handleInvoiceFundedV0(event: InvoiceFundedV1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoiceFunded(event, "v0");
 }
 
 export function handleInvoiceFundedV1(event: InvoiceFundedV1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoiceFunded(event, "v1");
 }
 
@@ -199,6 +202,9 @@ function handleInvoiceFundedV2_1or2(event: InvoiceFundedV2_1, version: string): 
   const underlyingClaim = getClaim(originatingClaimId.toString(), version);
   const InvoiceFundedEvent = createInvoiceFundedEventV2_1(originatingClaimId, event);
   const debtor = getOrCreateUser(Address.fromString(underlyingClaim.debtor));
+  getOrCreateBullaTransaction(ev.originalCreditor, event);
+  getOrCreateBullaTransaction(Address.fromString(underlyingClaim.debtor), event);
+  getOrCreateBullaTransaction(event.address, event);
 
   InvoiceFundedEvent.invoiceId = underlyingClaim.tokenId;
   InvoiceFundedEvent.fundedAmount = ev.fundedAmount;
@@ -260,7 +266,7 @@ function handleInvoiceFundedV2_1or2(event: InvoiceFundedV2_1, version: string): 
 }
 
 export function handleInvoiceFundedV2_1(event: InvoiceFundedV2_1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoiceFundedV2_1or2(event, "v2_1");
 }
 
@@ -281,6 +287,8 @@ function handleInvoiceKickbackAmountSent(event: InvoiceKickbackAmountSentV2_1, v
   InvoiceKickbackAmountSentEvent.originalCreditor = ev.originalCreditor;
   const original_creditor = getOrCreateUser(ev.originalCreditor);
   const pool = getOrCreateUser(event.address);
+  getOrCreateBullaTransaction(ev.originalCreditor, event);
+  getOrCreateBullaTransaction(event.address, event);
   const priceBeforeTransaction = getPriceBeforeTransaction(event);
   const price_per_share = getOrCreatePricePerShare(event, version);
   const latestPrice = getLatestPrice(event, version);
@@ -318,17 +326,17 @@ function handleInvoiceKickbackAmountSent(event: InvoiceKickbackAmountSentV2_1, v
 }
 
 export function handleInvoiceKickbackAmountSentV0(event: InvoiceKickbackAmountSentV0): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoiceKickbackAmountSent(changetype<InvoiceKickbackAmountSentV2_1>(event), "v0");
 }
 
 export function handleInvoiceKickbackAmountSentV1(event: InvoiceKickbackAmountSentV1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoiceKickbackAmountSent(changetype<InvoiceKickbackAmountSentV2_1>(event), "v1");
 }
 
 export function handleInvoiceKickbackAmountSentV2_1(event: InvoiceKickbackAmountSentV2_1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoiceKickbackAmountSent(event, "v2_1");
 }
 
@@ -338,7 +346,7 @@ export function handleInvoiceKickbackAmountSentV2_1(event: InvoiceKickbackAmount
 
 // V0: ActivePaidInvoicesReconciled (batch event)
 export function handleActivePaidInvoicesReconciledV0(event: ActivePaidInvoicesReconciled): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   let pnlTotal = BigInt.fromI32(0);
   const pool = getOrCreateUser(event.address);
@@ -349,6 +357,8 @@ export function handleActivePaidInvoicesReconciledV0(event: ActivePaidInvoicesRe
 
     const originalCreditorAddress = getApprovedInvoiceOriginalCreditor(event.address, "v0", invoiceId);
     const originalCreditor = getOrCreateUser(originalCreditorAddress);
+    getOrCreateBullaTransaction(originalCreditorAddress, event);
+    getOrCreateBullaTransaction(event.address, event);
 
     InvoiceReconciledEvent.poolAddress = event.address;
 
@@ -419,7 +429,7 @@ export function handleActivePaidInvoicesReconciledV0(event: ActivePaidInvoicesRe
 
 // V1: InvoicePaid
 export function handleInvoicePaidV1(event: InvoicePaidV1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev: InvoicePaid__Params = event.params;
   const originatingClaimId = ev.invoiceId;
 
@@ -440,6 +450,8 @@ export function handleInvoicePaidV1(event: InvoicePaidV1): void {
 
   const original_creditor = getOrCreateUser(ev.originalCreditor);
   const pool = getOrCreateUser(event.address);
+  getOrCreateBullaTransaction(ev.originalCreditor, event);
+  getOrCreateBullaTransaction(event.address, event);
   const priceBeforeTransaction = getPriceBeforeTransaction(event);
   const price_per_share = getOrCreatePricePerShare(event, "v1");
   const latestPrice = getLatestPrice(event, "v1");
@@ -495,6 +507,8 @@ function handleInvoicePaidV2_1or2(event: InvoicePaidV2_1, version: string): void
 
   const original_creditor = getOrCreateUser(ev.originalCreditor);
   const pool = getOrCreateUser(event.address);
+  getOrCreateBullaTransaction(ev.originalCreditor, event);
+  getOrCreateBullaTransaction(event.address, event);
 
   InvoiceReconciledEvent.invoiceId = underlyingClaim.tokenId;
   InvoiceReconciledEvent.trueAdminFee = ev.trueAdminFee;
@@ -552,7 +566,7 @@ function handleInvoicePaidV2_1or2(event: InvoicePaidV2_1, version: string): void
 }
 
 export function handleInvoicePaidV2_1(event: InvoicePaidV2_1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoicePaidV2_1or2(event, "v2_1");
 }
 
@@ -562,7 +576,7 @@ export function handleInvoicePaidV2_1(event: InvoicePaidV2_1): void {
 
 // V0: InvoiceUnfactored(indexed uint256,address,uint256,uint256)
 export function handleInvoiceUnfactoredV0(event: InvoiceUnfactoredV0): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const originatingClaimId = ev.invoiceId;
 
@@ -579,6 +593,8 @@ export function handleInvoiceUnfactoredV0(event: InvoiceUnfactoredV0): void {
   InvoiceUnfactoredEvent.originalCreditor = ev.originalCreditor;
   const original_creditor = getOrCreateUser(ev.originalCreditor);
   const pool = getOrCreateUser(event.address);
+  getOrCreateBullaTransaction(ev.originalCreditor, event);
+  getOrCreateBullaTransaction(event.address, event);
   const priceBeforeTransaction = getPriceBeforeTransaction(event);
   const price_per_share = getOrCreatePricePerShare(event, "v0");
   const latestPrice = getLatestPrice(event, "v0");
@@ -623,7 +639,7 @@ export function handleInvoiceUnfactoredV0(event: InvoiceUnfactoredV0): void {
 
 // V1: InvoiceUnfactored(indexed uint256,address,int256,uint256)
 export function handleInvoiceUnfactoredV1(event: InvoiceUnfactoredV1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const originatingClaimId = ev.invoiceId;
 
@@ -653,6 +669,8 @@ export function handleInvoiceUnfactoredV1(event: InvoiceUnfactoredV1): void {
   InvoiceUnfactoredEvent.originalCreditor = ev.originalCreditor;
   const original_creditor = getOrCreateUser(ev.originalCreditor);
   const pool = getOrCreateUser(event.address);
+  getOrCreateBullaTransaction(ev.originalCreditor, event);
+  getOrCreateBullaTransaction(event.address, event);
   const priceBeforeTransaction = getPriceBeforeTransaction(event);
   const price_per_share = getOrCreatePricePerShare(event, "v1");
   const latestPrice = getLatestPrice(event, "v1");
@@ -710,6 +728,8 @@ function handleInvoiceUnfactoredV2_1or2(event: InvoiceUnfactoredV2_1, version: s
   InvoiceUnfactoredEvent.originalCreditor = ev.originalCreditor;
   const original_creditor = getOrCreateUser(ev.originalCreditor);
   const pool = getOrCreateUser(event.address);
+  getOrCreateBullaTransaction(ev.originalCreditor, event);
+  getOrCreateBullaTransaction(event.address, event);
   const priceBeforeTransaction = getPriceBeforeTransaction(event);
   const price_per_share = getOrCreatePricePerShare(event, version);
   const latestPrice = getLatestPrice(event, version);
@@ -753,7 +773,7 @@ function handleInvoiceUnfactoredV2_1or2(event: InvoiceUnfactoredV2_1, version: s
 }
 
 export function handleInvoiceUnfactoredV2_1(event: InvoiceUnfactoredV2_1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoiceUnfactoredV2_1or2(event, "v2_1");
 }
 
@@ -763,7 +783,7 @@ export function handleInvoiceUnfactoredV2_1(event: InvoiceUnfactoredV2_1): void 
 
 // V0: DepositMade(indexed address,uint256,uint256)
 export function handleDepositMadeV0(event: DepositMade): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
 
   // Create FactoringPool entity if it doesn't exist (for pools not created via factory)
@@ -778,6 +798,8 @@ export function handleDepositMadeV0(event: DepositMade): void {
 
   const investor = getOrCreateUser(ev.depositor);
   const pool = getOrCreateUser(event.address);
+  getOrCreateBullaTransaction(ev.depositor, event);
+  getOrCreateBullaTransaction(event.address, event);
   const priceBeforeTransaction = getPriceBeforeTransaction(event);
   const price_per_share = getOrCreatePricePerShare(event, "v0");
   const latestPrice = getLatestPrice(event, "v0");
@@ -823,6 +845,8 @@ function handleDeposit(event: DepositV1, version: string): void {
 
   const investor = getOrCreateUser(ev.sender);
   const pool = getOrCreateUser(event.address);
+  getOrCreateBullaTransaction(ev.sender, event);
+  getOrCreateBullaTransaction(event.address, event);
   const priceBeforeTransaction = getPriceBeforeTransaction(event);
   const price_per_share = getOrCreatePricePerShare(event, version);
   const latestPrice = getLatestPrice(event, version);
@@ -853,12 +877,12 @@ function handleDeposit(event: DepositV1, version: string): void {
 }
 
 export function handleDepositV1(event: DepositV1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleDeposit(event, "v1");
 }
 
 export function handleDepositV2_1(event: DepositV2_1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleDeposit(changetype<DepositV1>(event), "v2_1");
 }
 
@@ -868,7 +892,7 @@ export function handleDepositV2_1(event: DepositV2_1): void {
 
 // V0: SharesRedeemed(indexed address,uint256,uint256)
 export function handleSharesRedeemedV0(event: SharesRedeemed): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
 
   const SharesRedeemedEvent = createSharesRedeemedEventV0(event);
@@ -879,6 +903,7 @@ export function handleSharesRedeemedV0(event: SharesRedeemed): void {
   SharesRedeemedEvent.shares = ev.shares;
   const investor = getOrCreateUser(ev.redeemer);
   const pool = getOrCreateUser(ev.redeemer);
+  getOrCreateBullaTransaction(ev.redeemer, event);
   const priceBeforeTransaction = getPriceBeforeTransaction(event);
   const price_per_share = getOrCreatePricePerShare(event, "v0");
   const latestPrice = getLatestPrice(event, "v0");
@@ -917,6 +942,7 @@ function handleWithdraw(event: WithdrawV1, version: string): void {
   SharesRedeemedEvent.shares = ev.shares;
   const investor = getOrCreateUser(ev.receiver);
   const pool = getOrCreateUser(ev.receiver);
+  getOrCreateBullaTransaction(ev.receiver, event);
   const priceBeforeTransaction = getPriceBeforeTransaction(event);
   const price_per_share = getOrCreatePricePerShare(event, version);
   const latestPrice = getLatestPrice(event, version);
@@ -944,12 +970,12 @@ function handleWithdraw(event: WithdrawV1, version: string): void {
 }
 
 export function handleWithdrawV1(event: WithdrawV1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleWithdraw(event, "v1");
 }
 
 export function handleWithdrawV2_1(event: WithdrawV2_1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleWithdraw(changetype<WithdrawV1>(event), "v2_1");
 }
 
@@ -968,6 +994,7 @@ function handleInvoiceImpaired(event: InvoiceImpaired, version: string): void {
 
   InvoiceImpairedEvent.invoiceId = underlyingClaim.tokenId;
   const pool = getOrCreateUser(event.address);
+  getOrCreateBullaTransaction(event.address, event);
   const priceBeforeTransaction = getPriceBeforeTransaction(event);
   const price_per_share = getOrCreatePricePerShare(event, version);
   const latestPrice = getLatestPrice(event, version);
@@ -1002,12 +1029,12 @@ function handleInvoiceImpaired(event: InvoiceImpaired, version: string): void {
 }
 
 export function handleInvoiceImpairedV0(event: InvoiceImpaired): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoiceImpaired(event, "v0");
 }
 
 export function handleInvoiceImpairedV1(event: InvoiceImpaired): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoiceImpaired(event, "v1");
 }
 
@@ -1023,7 +1050,7 @@ export function handleInvoiceImpairedV1(event: InvoiceImpaired): void {
 // the frontend needs the pre-fees value. V2_1 doesn't emit InvoiceImpaired
 // at all — gap documented in the schema comment.
 export function handleInvoiceImpairedV2_2(event: InvoiceImpairedV2_2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const originatingClaimId = ev.invoiceId;
 
@@ -1033,6 +1060,7 @@ export function handleInvoiceImpairedV2_2(event: InvoiceImpairedV2_2): void {
 
   InvoiceImpairedEvent.invoiceId = underlyingClaim.tokenId;
   const pool = getOrCreateUser(event.address);
+  getOrCreateBullaTransaction(event.address, event);
   const priceBeforeTransaction = getPriceBeforeTransaction(event);
   const price_per_share = getOrCreatePricePerShare(event, "v2_2");
   const latestPrice = getLatestPrice(event, "v2_2");
@@ -1067,21 +1095,21 @@ export function handleInvoiceImpairedV2_2(event: InvoiceImpairedV2_2): void {
 // ============================================================================
 
 export function handleDepositPermissionsChangedV0(event: DepositPermissionsChangedV0): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v0");
   poolPermissions.depositPermissions = event.params.newAddress;
   poolPermissions.save();
 }
 
 export function handleDepositPermissionsChangedV1(event: DepositPermissionsChangedV1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v1");
   poolPermissions.depositPermissions = event.params.newAddress;
   poolPermissions.save();
 }
 
 export function handleDepositPermissionsChangedV2_1(event: DepositPermissionsChangedV2_1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v2_1");
   poolPermissions.depositPermissions = event.params.newAddress;
   poolPermissions.save();
@@ -1092,21 +1120,21 @@ export function handleDepositPermissionsChangedV2_1(event: DepositPermissionsCha
 // ============================================================================
 
 export function handleFactoringPermissionsChangedV0(event: FactoringPermissionsChangedV0): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v0");
   poolPermissions.factoringPermissions = event.params.newAddress;
   poolPermissions.save();
 }
 
 export function handleFactoringPermissionsChangedV1(event: FactoringPermissionsChangedV1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v1");
   poolPermissions.factoringPermissions = event.params.newAddress;
   poolPermissions.save();
 }
 
 export function handleFactoringPermissionsChangedV2_1(event: FactoringPermissionsChangedV2_1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v2_1");
   poolPermissions.factoringPermissions = event.params.newAddress;
   poolPermissions.save();
@@ -1117,7 +1145,7 @@ export function handleFactoringPermissionsChangedV2_1(event: FactoringPermission
 // ============================================================================
 
 export function handleRedeemPermissionsChangedV2_1(event: RedeemPermissionsChangedV2_1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v2_1");
   poolPermissions.redeemPermissions = event.params.newAddress;
   poolPermissions.save();
@@ -1168,7 +1196,7 @@ function handleInvoiceApprovedV2_1or2(event: InvoiceApprovedV2_1, version: strin
 }
 
 export function handleInvoiceApprovedV2_1(event: InvoiceApprovedV2_1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoiceApprovedV2_1or2(event, "v2_1");
 }
 
@@ -1178,58 +1206,58 @@ export function handleInvoiceApprovedV2_1(event: InvoiceApprovedV2_1): void {
 
 // Shared events (same signature as V2_1): delegate via changetype
 export function handleInvoiceFundedV2_2(event: InvoiceFundedV2_2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoiceFundedV2_1or2(changetype<InvoiceFundedV2_1>(event), "v2_2");
 }
 
 export function handleInvoiceKickbackAmountSentV2_2(event: InvoiceKickbackAmountSentV2_1): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoiceKickbackAmountSent(event, "v2_2");
 }
 
 export function handleInvoicePaidV2_2(event: InvoicePaidV2_2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoicePaidV2_1or2(changetype<InvoicePaidV2_1>(event), "v2_2");
 }
 
 export function handleInvoiceUnfactoredV2_2(event: InvoiceUnfactoredV2_2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoiceUnfactoredV2_1or2(changetype<InvoiceUnfactoredV2_1>(event), "v2_2");
 }
 
 export function handleDepositV2_2(event: DepositV2_2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleDeposit(changetype<DepositV1>(event), "v2_2");
 }
 
 export function handleWithdrawV2_2(event: WithdrawV2_2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleWithdraw(changetype<WithdrawV1>(event), "v2_2");
 }
 
 export function handleDepositPermissionsChangedV2_2(event: DepositPermissionsChangedV2_2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v2_2");
   poolPermissions.depositPermissions = event.params.newAddress;
   poolPermissions.save();
 }
 
 export function handleFactoringPermissionsChangedV2_2(event: FactoringPermissionsChangedV2_2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v2_2");
   poolPermissions.factoringPermissions = event.params.newAddress;
   poolPermissions.save();
 }
 
 export function handleRedeemPermissionsChangedV2_2(event: RedeemPermissionsChangedV2_2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const poolPermissions = getOrCreatePoolPermissionsContractAddresses(event.address, "v2_2");
   poolPermissions.redeemPermissions = event.params.newAddress;
   poolPermissions.save();
 }
 
 export function handleInvoiceApprovedV2_2(event: InvoiceApprovedV2_2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   handleInvoiceApprovedV2_1or2(changetype<InvoiceApprovedV2_1>(event), "v2_2");
 }
 

--- a/bulla-contracts/src/mappings/BullaFactoringFactory.ts
+++ b/bulla-contracts/src/mappings/BullaFactoringFactory.ts
@@ -4,7 +4,7 @@ import { PoolCreatedEvent, FactoringPool } from "../../generated/schema";
 import { getOrCreateUser, getOrCreateBullaTransaction } from "../functions/common";
 
 export function handlePoolCreated(event: PoolCreated): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
 
   // Create the dynamic data source for the new pool

--- a/bulla-contracts/src/mappings/BullaFinance.ts
+++ b/bulla-contracts/src/mappings/BullaFinance.ts
@@ -8,7 +8,7 @@ import {
   CLAIM_FINANCING_KIND_OFFERED,
   CLAIM_FINANCING_ORIGINATION_VENDOR,
   getOrCreateClaimFinancing,
-  getOrCreateUser, getOrCreateBullaTransaction,} from "../functions/common";
+  getOrCreateUser, getOrCreateBullaTransaction, stampClaimParties,} from "../functions/common";
 import * as BullaBanker from "./BullaBanker";
 
 // this contract also emits BullaTagUpdatedEvents
@@ -27,8 +27,7 @@ export function handleFinancingOffered(event: FinancingOffered): void {
 
   const user_creditor = getOrCreateUser(Address.fromString(underlyingClaim.creditor));
   const user_debtor = getOrCreateUser(Address.fromString(underlyingClaim.debtor));
-  getOrCreateBullaTransaction(Address.fromString(underlyingClaim.creditor), event);
-  getOrCreateBullaTransaction(Address.fromString(underlyingClaim.debtor), event);
+  stampClaimParties(underlyingClaim, event);
 
   financingOfferedEvent.originatingClaimId = underlyingClaim.id;
   financingOfferedEvent.minDownPaymentBPS = ev.terms.minDownPaymentBPS;
@@ -74,8 +73,7 @@ export function handleFinancingAccepted(event: FinancingAccepted): void {
 
   const user_creditor = getOrCreateUser(Address.fromString(originatingClaim.creditor));
   const user_debtor = getOrCreateUser(Address.fromString(originatingClaim.debtor));
-  getOrCreateBullaTransaction(Address.fromString(originatingClaim.creditor), event);
-  getOrCreateBullaTransaction(Address.fromString(originatingClaim.debtor), event);
+  stampClaimParties(originatingClaim, event);
 
   financingAcceptedEvent.originatingClaimId = originatingClaim.id;
   financingAcceptedEvent.financedClaimId = financedClaim.id;

--- a/bulla-contracts/src/mappings/BullaFinance.ts
+++ b/bulla-contracts/src/mappings/BullaFinance.ts
@@ -13,12 +13,12 @@ import * as BullaBanker from "./BullaBanker";
 
 // this contract also emits BullaTagUpdatedEvents
 export function handleBullaTagUpdated(event: BullaTagUpdated): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   BullaBanker.handleBullaTagUpdated(event);
 }
 
 export function handleFinancingOffered(event: FinancingOffered): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const originatingClaimId = ev.originatingClaimId;
 
@@ -27,6 +27,8 @@ export function handleFinancingOffered(event: FinancingOffered): void {
 
   const user_creditor = getOrCreateUser(Address.fromString(underlyingClaim.creditor));
   const user_debtor = getOrCreateUser(Address.fromString(underlyingClaim.debtor));
+  getOrCreateBullaTransaction(Address.fromString(underlyingClaim.creditor), event);
+  getOrCreateBullaTransaction(Address.fromString(underlyingClaim.debtor), event);
 
   financingOfferedEvent.originatingClaimId = underlyingClaim.id;
   financingOfferedEvent.minDownPaymentBPS = ev.terms.minDownPaymentBPS;
@@ -61,7 +63,7 @@ export function handleFinancingOffered(event: FinancingOffered): void {
 }
 
 export function handleFinancingAccepted(event: FinancingAccepted): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const originatingClaimId = ev.originatingClaimId;
   const financedClaimId = ev.financedClaimId;
@@ -72,6 +74,8 @@ export function handleFinancingAccepted(event: FinancingAccepted): void {
 
   const user_creditor = getOrCreateUser(Address.fromString(originatingClaim.creditor));
   const user_debtor = getOrCreateUser(Address.fromString(originatingClaim.debtor));
+  getOrCreateBullaTransaction(Address.fromString(originatingClaim.creditor), event);
+  getOrCreateBullaTransaction(Address.fromString(originatingClaim.debtor), event);
 
   financingAcceptedEvent.originatingClaimId = originatingClaim.id;
   financingAcceptedEvent.financedClaimId = financedClaim.id;

--- a/bulla-contracts/src/mappings/BullaInstantPayment.ts
+++ b/bulla-contracts/src/mappings/BullaInstantPayment.ts
@@ -4,7 +4,9 @@ import { getInstantPaymentEventId, getInstantPaymentTagUpdatedId } from "../func
 import { getOrCreateToken, getOrCreateUser, hexStringToLowercase, getOrCreateBullaTransaction } from "../functions/common";
 
 export function handleInstantPayment(event: InstantPayment): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
+  getOrCreateBullaTransaction(event.params.from, event);
+  getOrCreateBullaTransaction(event.params.to, event);
   const token = getOrCreateToken(event.params.tokenAddress);
   const instantPaymentId = getInstantPaymentEventId(event.transaction.hash, event.logIndex);
   const user_from = getOrCreateUser(event.params.from);
@@ -53,7 +55,7 @@ export function handleInstantPayment(event: InstantPayment): void {
 }
 
 export function handleInstantPaymentTagUpdated(event: InstantPaymentTagUpdated): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const instantPaymentId: string = hexStringToLowercase(event.params.txAndLogIndexHash.toHexString());
   const instantPaymentEvent = InstantPaymentEvent.load(instantPaymentId);
 

--- a/bulla-contracts/src/mappings/BullaInvoice.ts
+++ b/bulla-contracts/src/mappings/BullaInvoice.ts
@@ -12,14 +12,15 @@ import {
   getPurchaseOrderDeliveredEventId,
   getPurchaseOrderState,
 } from "../functions/BullaInvoice";
-import { getOrCreateToken, getOrCreateUser, getOrCreateBullaTransaction } from "../functions/common";
+import { getOrCreateToken, getOrCreateUser, getOrCreateBullaTransaction, stampClaimParties } from "../functions/common";
 
 export function handleInvoiceCreated(event: InvoiceCreated): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const claimId = ev.claimId.toString();
   // Add the invoice created event to creditor and debtor's invoiceEvents
   const claim = getOrCreateClaim(claimId, "v2");
+  stampClaimParties(claim, event);
 
   // Create the PurchaseOrderState entity only if it's a purchase order
   const purchaseOrderState = createPurchaseOrderStateFromEvent(event);
@@ -83,10 +84,11 @@ export function handleInvoiceCreated(event: InvoiceCreated): void {
 }
 
 export function handleInvoicePaid(event: InvoicePaid): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const invoicePaidEvent = createInvoicePaidEvent(event);
   const claim = getOrCreateClaim(ev.claimId.toString(), "v2");
+  stampClaimParties(claim, event);
 
   invoicePaidEvent.claim = claim.id;
   invoicePaidEvent.grossInterestPaid = ev.grossInterestPaid;
@@ -116,7 +118,7 @@ export function handleInvoicePaid(event: InvoicePaid): void {
 }
 
 export function handlePurchaseOrderAccepted(event: PurchaseOrderAccepted): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const claimId = ev.claimId.toString();
 
@@ -133,6 +135,7 @@ export function handlePurchaseOrderAccepted(event: PurchaseOrderAccepted): void 
 
   // Update the underlying claim
   const claim = getOrCreateClaim(claimId, "v2");
+  stampClaimParties(claim, event);
 
   // Create the PurchaseOrderAcceptedEvent
   const purchaseOrderAcceptedEvent = createPurchaseOrderAcceptedEvent(event);
@@ -163,7 +166,7 @@ export function handlePurchaseOrderAccepted(event: PurchaseOrderAccepted): void 
 }
 
 export function handlePurchaseOrderDelivered(event: PurchaseOrderDelivered): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const claimId = ev.claimId.toString();
 
@@ -177,6 +180,7 @@ export function handlePurchaseOrderDelivered(event: PurchaseOrderDelivered): voi
 
   // Update the underlying claim
   const claim = getOrCreateClaim(claimId, "v2");
+  stampClaimParties(claim, event);
 
   const invoiceDetailsEntity = getOrCreateInvoiceDetails(claim.id, event);
   invoiceDetailsEntity.isDelivered = true;
@@ -210,8 +214,9 @@ export function handlePurchaseOrderDelivered(event: PurchaseOrderDelivered): voi
 }
 
 export function handleFeeWithdrawn(event: FeeWithdrawn): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
+  getOrCreateBullaTransaction(ev.admin, event); // admin receives the withdrawn fee
 
   // Create the FeeWithdrawnEvent
   const feeWithdrawnEvent = createFeeWithdrawnEvent(event);

--- a/bulla-contracts/src/mappings/BullaManager.ts
+++ b/bulla-contracts/src/mappings/BullaManager.ts
@@ -2,7 +2,7 @@ import { FeeChanged, CollectorChanged, OwnerChanged, BullaTokenChanged, FeeThres
 import { getOrCreateBullaManager, getOrCreateToken, getOrCreateUser, getOrCreateBullaTransaction } from "../functions/common";
 
 export function handleFeeChanged(event: FeeChanged): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const bullaManager = getOrCreateBullaManager(event);
   bullaManager.feeBasisPoints = ev.newFee.toI32();
@@ -13,7 +13,7 @@ export function handleFeeChanged(event: FeeChanged): void {
 }
 
 export function handleCollectorChanged(event: CollectorChanged): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const bullaManager = getOrCreateBullaManager(event);
   const user = getOrCreateUser(ev.newCollector);
@@ -26,7 +26,7 @@ export function handleCollectorChanged(event: CollectorChanged): void {
 }
 
 export function handleOwnerChanged(event: OwnerChanged): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const bullaManager = getOrCreateBullaManager(event);
 
@@ -38,7 +38,7 @@ export function handleOwnerChanged(event: OwnerChanged): void {
 }
 
 export function handleBullaTokenChanged(event: BullaTokenChanged): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const token = getOrCreateToken(ev.newBullaToken);
   const bullaManager = getOrCreateBullaManager(event);
@@ -51,7 +51,7 @@ export function handleBullaTokenChanged(event: BullaTokenChanged): void {
 }
 
 export function handleFeeThresholdChanged(event: FeeThresholdChanged): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const bullaManager = getOrCreateBullaManager(event);
 
@@ -63,7 +63,7 @@ export function handleFeeThresholdChanged(event: FeeThresholdChanged): void {
 }
 
 export function handleReducedFeeChanged(event: ReducedFeeChanged): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const bullaManager = getOrCreateBullaManager(event);
 

--- a/bulla-contracts/src/mappings/BullaSwap.ts
+++ b/bulla-contracts/src/mappings/BullaSwap.ts
@@ -11,7 +11,7 @@ import {
 import { getOrCreateUser, getOrCreateBullaTransaction } from "../functions/common";
 
 export function handleOrderCreated(event: OrderCreated): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const orderId = ev.orderId;
 
@@ -44,16 +44,18 @@ export function handleOrderCreated(event: OrderCreated): void {
   const sender = getOrCreateUser(ev.sender);
   sender.swapEvents = sender.swapEvents ? sender.swapEvents.concat([orderCreatedEvent.id]) : [orderCreatedEvent.id];
   sender.save();
+  getOrCreateBullaTransaction(ev.sender, event);
 
   const signer = getOrCreateUser(ev.signerWallet);
   signer.swapEvents = signer.swapEvents ? signer.swapEvents.concat([orderCreatedEvent.id]) : [orderCreatedEvent.id];
   signer.save();
+  getOrCreateBullaTransaction(ev.signerWallet, event);
 
   orderCreatedEvent.save();
 }
 
 export function handleOrderExecuted(event: OrderExecuted): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const orderId = ev.orderId;
 
@@ -88,16 +90,18 @@ export function handleOrderExecuted(event: OrderExecuted): void {
   const sender = getOrCreateUser(ev.sender);
   sender.swapEvents = sender.swapEvents ? sender.swapEvents.concat([orderExecutedEvent.id]) : [orderExecutedEvent.id];
   sender.save();
+  getOrCreateBullaTransaction(ev.sender, event);
 
   const recipient = getOrCreateUser(ev.recipient);
   recipient.swapEvents = recipient.swapEvents ? recipient.swapEvents.concat([orderExecutedEvent.id]) : [orderExecutedEvent.id];
   recipient.save();
+  getOrCreateBullaTransaction(ev.recipient, event);
 
   orderExecutedEvent.save();
 }
 
 export function handleOrderDeleted(event: OrderDeleted): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const orderId = ev.orderId;
 
@@ -130,10 +134,12 @@ export function handleOrderDeleted(event: OrderDeleted): void {
   const signer = getOrCreateUser(ev.order.signerWallet);
   signer.swapEvents = signer.swapEvents ? signer.swapEvents.concat([orderDeletedEvent.id]) : [orderDeletedEvent.id];
   signer.save();
+  getOrCreateBullaTransaction(ev.order.signerWallet, event);
 
   const sender = getOrCreateUser(ev.order.senderWallet);
   sender.swapEvents = sender.swapEvents ? sender.swapEvents.concat([orderDeletedEvent.id]) : [orderDeletedEvent.id];
   sender.save();
+  getOrCreateBullaTransaction(ev.order.senderWallet, event);
 
   orderDeletedEvent.save();
 }

--- a/bulla-contracts/src/mappings/FrendLend.ts
+++ b/bulla-contracts/src/mappings/FrendLend.ts
@@ -39,12 +39,12 @@ import * as BullaBanker from "./BullaBanker";
 
 // this contract also emits BullaTagUpdatedEvents
 export function handleBullaTagUpdated(event: BullaTagUpdated): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   BullaBanker.handleBullaTagUpdated(event);
 }
 
 export function handleLoanOffered(event: LoanOffered): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const offer = event.params.loanOffer;
 
@@ -52,6 +52,9 @@ export function handleLoanOffered(event: LoanOffered): void {
 
   const user_creditor = getOrCreateUser(offer.creditor);
   const user_debtor = getOrCreateUser(offer.debtor);
+  getOrCreateBullaTransaction(offer.creditor, event);
+  getOrCreateBullaTransaction(offer.debtor, event);
+  getOrCreateBullaTransaction(ev.offeredBy, event);
 
   loanOfferedEvent.loanId = ev.loanId.toString();
   loanOfferedEvent.version = BULLA_CLAIM_VERSION_V1;
@@ -97,7 +100,7 @@ export function handleLoanOffered(event: LoanOffered): void {
 }
 
 export function handleLoanOfferedV2(event: LoanOfferedV2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const offer = event.params.loanOffer;
   const metadata = event.params.metadata;
@@ -106,6 +109,9 @@ export function handleLoanOfferedV2(event: LoanOfferedV2): void {
 
   const user_creditor = getOrCreateUser(offer.creditor);
   const user_debtor = getOrCreateUser(offer.debtor);
+  getOrCreateBullaTransaction(offer.creditor, event);
+  getOrCreateBullaTransaction(offer.debtor, event);
+  getOrCreateBullaTransaction(ev.offeredBy, event);
 
   loanOfferedEvent.loanId = ev.offerId.toString();
   loanOfferedEvent.version = BULLA_CLAIM_VERSION_V2;
@@ -158,7 +164,7 @@ export function handleLoanOfferedV2(event: LoanOfferedV2): void {
 }
 
 export function handleLoanOfferAccepted(event: LoanOfferAccepted): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const loanId = event.params.loanId;
 
@@ -167,6 +173,8 @@ export function handleLoanOfferAccepted(event: LoanOfferAccepted): void {
 
   const user_creditor = getOrCreateUser(Address.fromString(loanOfferedEvent.creditor.toHexString()));
   const user_debtor = getOrCreateUser(Address.fromString(loanOfferedEvent.debtor.toHexString()));
+  getOrCreateBullaTransaction(Address.fromString(loanOfferedEvent.creditor.toHexString()), event);
+  getOrCreateBullaTransaction(Address.fromString(loanOfferedEvent.debtor.toHexString()), event);
 
   loanOfferAcceptedEvent.loanId = loanId.toString();
   loanOfferAcceptedEvent.version = BULLA_CLAIM_VERSION_V1;
@@ -220,7 +228,7 @@ export function handleLoanOfferAccepted(event: LoanOfferAccepted): void {
 }
 
 export function handleLoanOfferAcceptedV2(event: LoanOfferAcceptedV2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const offerId = event.params.offerId;
 
@@ -229,6 +237,9 @@ export function handleLoanOfferAcceptedV2(event: LoanOfferAcceptedV2): void {
 
   const user_creditor = getOrCreateUser(Address.fromString(loanOfferedEvent.creditor.toHexString()));
   const user_debtor = getOrCreateUser(Address.fromString(loanOfferedEvent.debtor.toHexString()));
+  getOrCreateBullaTransaction(Address.fromString(loanOfferedEvent.creditor.toHexString()), event);
+  getOrCreateBullaTransaction(Address.fromString(loanOfferedEvent.debtor.toHexString()), event);
+  getOrCreateBullaTransaction(ev.receiver, event);
 
   loanOfferAcceptedEvent.loanId = offerId.toString();
   loanOfferAcceptedEvent.version = BULLA_CLAIM_VERSION_V2;
@@ -282,7 +293,7 @@ export function handleLoanOfferAcceptedV2(event: LoanOfferAcceptedV2): void {
 }
 
 export function handleLoanOfferRejected(event: LoanOfferRejected): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const loanId = event.params.loanId;
 
@@ -291,6 +302,9 @@ export function handleLoanOfferRejected(event: LoanOfferRejected): void {
 
   const user_creditor = getOrCreateUser(Address.fromString(loanOfferedEvent.creditor.toHexString()));
   const user_debtor = getOrCreateUser(Address.fromString(loanOfferedEvent.debtor.toHexString()));
+  getOrCreateBullaTransaction(Address.fromString(loanOfferedEvent.creditor.toHexString()), event);
+  getOrCreateBullaTransaction(Address.fromString(loanOfferedEvent.debtor.toHexString()), event);
+  getOrCreateBullaTransaction(ev.rejectedBy, event);
 
   loanOfferRejectedEvent.loanId = loanId.toString();
   loanOfferRejectedEvent.version = BULLA_CLAIM_VERSION_V1;
@@ -318,11 +332,12 @@ export function handleLoanOfferRejected(event: LoanOfferRejected): void {
 }
 
 export function handleFeeWithdrawn(event: FeeWithdrawn): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
 
   const feeWithdrawnEvent = createFeeWithdrawnEvent(event);
   const user_admin = getOrCreateUser(ev.admin);
+  getOrCreateBullaTransaction(ev.admin, event);
 
   feeWithdrawnEvent.admin = ev.admin;
   feeWithdrawnEvent.token = getOrCreateToken(ev.token).id;
@@ -341,7 +356,7 @@ export function handleFeeWithdrawn(event: FeeWithdrawn): void {
 }
 
 export function handleLoanPayment(event: LoanPayment): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
 
   const loanPaymentEvent = createLoanPaymentEvent(event);
@@ -400,6 +415,8 @@ export function handleLoanPayment(event: LoanPayment): void {
   // Add the loan payment event to creditor and debtor's frendLendEvents
   const user_creditor = getOrCreateUser(Address.fromString(claim.creditor));
   const user_debtor = getOrCreateUser(Address.fromString(claim.debtor));
+  getOrCreateBullaTransaction(Address.fromString(claim.creditor), event);
+  getOrCreateBullaTransaction(Address.fromString(claim.debtor), event);
 
   user_creditor.frendLendEvents = user_creditor.frendLendEvents ? user_creditor.frendLendEvents.concat([loanPaymentEvent.id]) : [loanPaymentEvent.id];
   user_debtor.frendLendEvents = user_debtor.frendLendEvents ? user_debtor.frendLendEvents.concat([loanPaymentEvent.id]) : [loanPaymentEvent.id];
@@ -409,7 +426,7 @@ export function handleLoanPayment(event: LoanPayment): void {
 }
 
 export function handleLoanOfferRejectedV2(event: LoanOfferRejectedV2): void {
-  getOrCreateBullaTransaction(event);
+  getOrCreateBullaTransaction(event.transaction.from, event);
   const ev = event.params;
   const offerId = event.params.offerId;
 
@@ -418,6 +435,9 @@ export function handleLoanOfferRejectedV2(event: LoanOfferRejectedV2): void {
 
   const user_creditor = getOrCreateUser(Address.fromString(loanOfferedEvent.creditor.toHexString()));
   const user_debtor = getOrCreateUser(Address.fromString(loanOfferedEvent.debtor.toHexString()));
+  getOrCreateBullaTransaction(Address.fromString(loanOfferedEvent.creditor.toHexString()), event);
+  getOrCreateBullaTransaction(Address.fromString(loanOfferedEvent.debtor.toHexString()), event);
+  getOrCreateBullaTransaction(ev.rejectedBy, event);
 
   loanOfferRejectedEvent.loanId = offerId.toString();
   loanOfferRejectedEvent.version = BULLA_CLAIM_VERSION_V2;

--- a/bulla-contracts/src/mappings/FrendLend.ts
+++ b/bulla-contracts/src/mappings/FrendLend.ts
@@ -22,7 +22,7 @@ import {
   getOrCreateUser,
   LOAN_OFFER_STATUS_ACCEPTED,
   LOAN_OFFER_STATUS_OFFERED,
-  LOAN_OFFER_STATUS_REJECTED, getOrCreateBullaTransaction,} from "../functions/common";
+  LOAN_OFFER_STATUS_REJECTED, getOrCreateBullaTransaction, stampClaimParties,} from "../functions/common";
 import {
   createFeeWithdrawnEvent,
   createLoanOfferAcceptedEvent,
@@ -194,6 +194,7 @@ export function handleLoanOfferAccepted(event: LoanOfferAccepted): void {
   // v1 frendlend creates the claim with a 1-wei sentinel baked into amount and
   // paidAmount; surface the net values so consumers don't re-walk logs.
   const claim = getClaim(ev.claimId.toString(), "v1");
+  stampClaimParties(claim, event);
 
   // Flip the denormalized loan-offer lifecycle to Accepted and link the claim.
   const loanOffer = getOrCreateLoanOffer(loanId.toString(), "v1", event);
@@ -261,6 +262,7 @@ export function handleLoanOfferAcceptedV2(event: LoanOfferAcceptedV2): void {
 
   // Denormalized financing state on the loan claim created by acceptance.
   const claim = getOrCreateClaim(ev.claimId.toString(), BULLA_CLAIM_VERSION_V2);
+  stampClaimParties(claim, event);
 
   // Flip the denormalized loan-offer lifecycle to Accepted and link the claim.
   const loanOffer = getOrCreateLoanOffer(offerId.toString(), "v2", event);
@@ -415,8 +417,7 @@ export function handleLoanPayment(event: LoanPayment): void {
   // Add the loan payment event to creditor and debtor's frendLendEvents
   const user_creditor = getOrCreateUser(Address.fromString(claim.creditor));
   const user_debtor = getOrCreateUser(Address.fromString(claim.debtor));
-  getOrCreateBullaTransaction(Address.fromString(claim.creditor), event);
-  getOrCreateBullaTransaction(Address.fromString(claim.debtor), event);
+  stampClaimParties(claim, event);
 
   user_creditor.frendLendEvents = user_creditor.frendLendEvents ? user_creditor.frendLendEvents.concat([loanPaymentEvent.id]) : [loanPaymentEvent.id];
   user_debtor.frendLendEvents = user_debtor.frendLendEvents ? user_debtor.frendLendEvents.concat([loanPaymentEvent.id]) : [loanPaymentEvent.id];

--- a/bulla-contracts/tests/BullaSwap.test.ts
+++ b/bulla-contracts/tests/BullaSwap.test.ts
@@ -173,8 +173,8 @@ test("it records a BullaTransaction for the handled tx", () => {
 
   handleOrderCreated(orderCreatedEvent);
 
-  // One idempotent BullaTransaction row keyed by txHash; user is the tx sender.
-  const txId = orderCreatedEvent.transaction.hash.toHexString();
+  // One idempotent BullaTransaction row per (user, tx); id is `${user}-${txHash}`.
+  const txId = orderCreatedEvent.transaction.from.toHexString() + "-" + orderCreatedEvent.transaction.hash.toHexString();
   assert.fieldEquals("BullaTransaction", txId, "txHash", orderCreatedEvent.transaction.hash.toHexString());
   assert.fieldEquals("BullaTransaction", txId, "user", orderCreatedEvent.transaction.from.toHexString());
   assert.fieldEquals("BullaTransaction", txId, "timestamp", timestamp.toString());


### PR DESCRIPTION
BullaTransaction was keyed by txHash alone and filed only under the tx sender, so any wallet that merely received value in a Bulla tx (instant-payment recipient, claim creditor, etc.) was missing from its bullaTxHashBitmap

Addendum: every claim-touching handler (transfers included) now stamps the full {creditor, debtor, creator, controller} membership via stampClaimParties, not just the event's direct party